### PR TITLE
Added distributed memory cache to web if in development in aodp.web -…

### DIFF
--- a/src/SFA.DAS.AODP.Authentication/Extensions/AddServiceRegistrationExtension.cs
+++ b/src/SFA.DAS.AODP.Authentication/Extensions/AddServiceRegistrationExtension.cs
@@ -46,21 +46,6 @@ namespace SFA.DAS.AODP.Authentication.Extensions
             services.AddSingleton<ITicketStore, AuthenticationTicketStore>();
 
             var connection = configuration.GetSection(nameof(DfEOidcConfiguration)).Get<DfEOidcConfiguration>();
-            if (string.IsNullOrEmpty(connection.DfELoginSessionConnectionString))
-            {
-#if NETSTANDARD2_0
-                services.AddMemoryCache();
-#else
-                services.AddDistributedMemoryCache();
-#endif
-            }
-            else
-            {
-                services.AddStackExchangeRedisCache(options =>
-                {
-                    options.Configuration = connection.DfELoginSessionConnectionString;
-                });
-            }
         }
 
         private static IAsyncPolicy<HttpResponseMessage> HttpClientRetryPolicy()

--- a/src/SFA.DAS.AODP.Web/Extensions/AddDataProtectionExtensions.cs
+++ b/src/SFA.DAS.AODP.Web/Extensions/AddDataProtectionExtensions.cs
@@ -16,7 +16,7 @@ public static class AddDataProtectionExtensions
                 .AddDataProtection()
                 .SetApplicationName(applicationName)
                 .PersistKeysToFileSystem(new DirectoryInfo(Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "keys")));
-
+            services.AddDistributedMemoryCache();
         }
         else
         {


### PR DESCRIPTION
Added distributed memory cache to web if in development in aodp.web - currently after dataprotect in "indevelopment" flow. Ran and tested locally for login and  direct page navigation. Removed caching references in aodp.authentication as ticket store will use what is defined in program.cs to my knowledge via DI.
The code is as was in terms of the openid config from sprint 3.