### PR TITLE
Defaulting ao apply route to the the apply controller as the applicat…

### DIFF
--- a/src/SFA.DAS.AODP.Web/Areas/Admin/Controllers/DashboardController.cs
+++ b/src/SFA.DAS.AODP.Web/Areas/Admin/Controllers/DashboardController.cs
@@ -3,7 +3,7 @@
 namespace SFA.DAS.AODP.Web.Areas.Admin.Controllers
 {
     [Area("Admin")]
-    public class FormsBuilderController : Controller
+    public class DashboardController : Controller
     {
         public async Task<IActionResult> Index()
         {

--- a/src/SFA.DAS.AODP.Web/Areas/Admin/Views/Dashboard/Index.cshtml
+++ b/src/SFA.DAS.AODP.Web/Areas/Admin/Views/Dashboard/Index.cshtml
@@ -1,0 +1,35 @@
+﻿@using System.Security.Claims
+@{
+	ViewData["Title"] = "Admin Dashboard";
+}
+
+<div class="govuk-width-container">
+	<main class="govuk-main-wrapper">
+		<div class="govuk-grid-row">
+			<div class="govuk-grid-column-two-thirds">
+				<div class="govuk-grid-row">
+					<h1 class="govuk-heading-1">Dashboard</h1>
+				</div>
+				<div class="govuk-grid-row">
+					<h2 class="govuk-heading-2">You are a Forms Builder user (DFE)</h2>
+				</div>
+				<div class="govuk-grid-row">
+					<label class="govuk-label govuk-label--s">Claims</label>
+				</div>
+				<table class="govuk-table">
+					<tr class="govuk-table__header">
+						<th>Type</th>
+						<th>Value</th>
+					</tr>
+					@foreach (var item in ((ClaimsIdentity)User.Identity).Claims)
+					{
+						<tr>
+							<td class="govuk-table__cell">@item.Type</td>
+							<td class="govuk-table__cell">@item.Value</td>
+						</tr>
+					}
+				</table>
+			</div>
+		</div>
+	</main>
+</div>

--- a/src/SFA.DAS.AODP.Web/Authentication/RoleConstants.cs
+++ b/src/SFA.DAS.AODP.Web/Authentication/RoleConstants.cs
@@ -6,7 +6,7 @@ static class RoleConstants
     public const string IFATEReviewer = "ifate_user_reviewer";
     public const string OFQUALReviewer = "ofqual_user_reviewer";
     public const string AOApply = "ao_user";
-    public const string QFAUFormBuilder = "qfau_admin_form_editor";
-    public const string IFATEFormBuilder = "ifate_admin_form_editor";
-    public const string QFAUImport = "qfau_admin_data_importer";
+    public const string QFAUFormBuilder = "qfau_admin_forms";
+    public const string IFATEFormBuilder = "ifate_admin_forms";
+    public const string QFAUImport = "qfau_admin_data";
 }

--- a/src/SFA.DAS.AODP.Web/Program.cs
+++ b/src/SFA.DAS.AODP.Web/Program.cs
@@ -121,7 +121,7 @@ internal class Program
                         defaults: new { area = "Admin", controller = "Import" }).RequireAuthorization(PolicyConstants.IsAdminImportUser);
 
         endpoints.MapControllerRoute(name: "AdminDefaultForForms",
-                                         pattern: "Admin/{controller=Forms}/{action=index}/{id?}",
+                                         pattern: "Admin/{controller=Dashboard}/{action=index}/{id?}",
                                          defaults: new { area = "Admin" }).RequireAuthorization(PolicyConstants.IsAdminFormsUser);
 
         endpoints.MapControllerRoute(name: "ApplyHome",

--- a/src/SFA.DAS.AODP.Web/Program.cs
+++ b/src/SFA.DAS.AODP.Web/Program.cs
@@ -130,6 +130,6 @@ internal class Program
 
         endpoints.MapAreaControllerRoute(name: "Apply",
                                        areaName: "Apply",
-                                       pattern: "{area:exists}/{controller=Application}/{action=Index}/{id?}").RequireAuthorization(PolicyConstants.IsApplyUser);
+                                       pattern: "{area:exists}/{controller=Apply}/{action=Index}/{id?}").RequireAuthorization(PolicyConstants.IsApplyUser);
     }
 }


### PR DESCRIPTION
Updates the apply route from the "application "controller to the "apply" controller.

Application controller uses attribute routing and overrides the conventional route defined in program.cs for the apply area

Application controller routing needs revisiting at some point.

Tested the apply route and the apply dashboard is now displayed. 