### PR TITLE
[AWARD-1151] - Fixed issue where QANs weren't being linked to the ofqual register

### DIFF
--- a/src/SFA.DAS.AODP.Web.Test/Areas/Review/Controllers/ChangedControllerBulkActionTests.cs
+++ b/src/SFA.DAS.AODP.Web.Test/Areas/Review/Controllers/ChangedControllerBulkActionTests.cs
@@ -27,7 +27,6 @@ public class ChangedControllerBulkActionTests
     private readonly Mock<ILogger<ChangedController>> _loggerMock;
     private readonly Mock<IUserHelperService> _userHelperMock;
     private readonly Mock<IMediator> _mediatorMock;
-    private readonly IOptions<AodpConfiguration> _aodpOptions;
     private readonly ChangedController _controller;
     private readonly Mock<IUrlHelper> _urlHelperMock;
 
@@ -39,14 +38,8 @@ public class ChangedControllerBulkActionTests
         _userHelperMock = _fixture.Freeze<Mock<IUserHelperService>>();
         _mediatorMock = _fixture.Freeze<Mock<IMediator>>();
 
-        _aodpOptions = Options.Create(new AodpConfiguration
-        {
-            FindRegulatedQualificationUrl = "https://find-a-qualification.services.ofqual.gov.uk/qualifications/"
-        });
-
         _controller = new ChangedController(
             _loggerMock.Object,
-            _aodpOptions,
             _mediatorMock.Object,
             _userHelperMock.Object);
 

--- a/src/SFA.DAS.AODP.Web.Test/Areas/Review/Controllers/ChangedControllerTests.cs
+++ b/src/SFA.DAS.AODP.Web.Test/Areas/Review/Controllers/ChangedControllerTests.cs
@@ -783,7 +783,6 @@ public class ChangedControllerTests
             Assert.Equal(SearchName, model.Filter.QualificationName);
             Assert.Equal(SearchOrganisation, model.Filter.Organisation);
             Assert.Equal(SearchQan, model.Filter.QAN);
-            Assert.Equal(DefaultFindQualificationUrl, model.FindRegulatedQualificationUrl);
         });
     }
 

--- a/src/SFA.DAS.AODP.Web.Test/Areas/Review/Controllers/ChangedControllerTests.cs
+++ b/src/SFA.DAS.AODP.Web.Test/Areas/Review/Controllers/ChangedControllerTests.cs
@@ -57,7 +57,7 @@ public class ChangedControllerTests
 
     private ChangedController CreateController()
     {
-        var controller = new ChangedController(_logger.Object, _options, _mediator.Object, _userHelper.Object);
+        var controller = new ChangedController(_logger.Object, _mediator.Object, _userHelper.Object);
 
         var httpContext = new DefaultHttpContext();
         var claims = new[] { new Claim(ClaimTypes.Name, DefaultUserName) };

--- a/src/SFA.DAS.AODP.Web.Test/Areas/Review/Controllers/NewControllerBulkActionTests.cs
+++ b/src/SFA.DAS.AODP.Web.Test/Areas/Review/Controllers/NewControllerBulkActionTests.cs
@@ -28,7 +28,6 @@ public class NewControllerBulkActionTests
     private readonly Mock<ILogger<NewController>> _loggerMock;
     private readonly Mock<IUserHelperService> _userHelperMock;
     private readonly Mock<IMediator> _mediatorMock;
-    private readonly IOptions<AodpConfiguration> _aodpOptions;
     private readonly NewController _controller;
     private readonly Mock<IUrlHelper> _urlHelperMock;
 
@@ -40,14 +39,8 @@ public class NewControllerBulkActionTests
         _userHelperMock = _fixture.Freeze<Mock<IUserHelperService>>();
         _mediatorMock = _fixture.Freeze<Mock<IMediator>>();
 
-        _aodpOptions = Options.Create(new AodpConfiguration
-        {
-            FindRegulatedQualificationUrl = "https://find-a-qualification.services.ofqual.gov.uk/qualifications/"
-        });
-
         _controller = new NewController(
             _loggerMock.Object,
-            _aodpOptions,
             _mediatorMock.Object,
             _userHelperMock.Object);
 

--- a/src/SFA.DAS.AODP.Web.Test/Areas/Review/Controllers/NewControllerTests.cs
+++ b/src/SFA.DAS.AODP.Web.Test/Areas/Review/Controllers/NewControllerTests.cs
@@ -64,12 +64,10 @@ public class NewControllerTests
     private readonly Mock<ILogger<NewController>> _logger = new();
     private readonly Mock<IMediator> _mediator = new();
     private readonly Mock<IUserHelperService> _userHelper = new();
-    private readonly IOptions<AodpConfiguration> _options =
-        Options.Create(new AodpConfiguration { FindRegulatedQualificationUrl = FindRegulatedQualificationUrl });
-
+   
     private NewController CreateController()
     {
-        var controller = new NewController(_logger.Object, _options, _mediator.Object, _userHelper.Object);
+        var controller = new NewController(_logger.Object, _mediator.Object, _userHelper.Object);
 
         var httpContext = new DefaultHttpContext();
         controller.ControllerContext = new ControllerContext { HttpContext = httpContext };

--- a/src/SFA.DAS.AODP.Web.Test/Areas/Review/Controllers/NewControllerTests.cs
+++ b/src/SFA.DAS.AODP.Web.Test/Areas/Review/Controllers/NewControllerTests.cs
@@ -111,7 +111,6 @@ public class NewControllerTests
         Assert.Multiple(() =>
         {
             Assert.Empty(model.NewQualifications);
-            Assert.Equal(FindRegulatedQualificationUrl, model.FindRegulatedQualificationUrl);
             Assert.NotNull(model.Filter);
             Assert.NotNull(model.ProcessStatuses);
         });
@@ -168,7 +167,6 @@ public class NewControllerTests
         {
             Assert.Single(model.NewQualifications);
             Assert.Equal(QualificationTitle, model.NewQualifications.First().Title);
-            Assert.Equal(FindRegulatedQualificationUrl, model.FindRegulatedQualificationUrl);
             Assert.NotNull(model.Filter);
             Assert.NotNull(model.ProcessStatuses);
         });

--- a/src/SFA.DAS.AODP.Web.Test/Controllers/ReviewChangedControllerTests.cs
+++ b/src/SFA.DAS.AODP.Web.Test/Controllers/ReviewChangedControllerTests.cs
@@ -23,10 +23,6 @@ public class ReviewChangedControllerTests
     private readonly Mock<IUserHelperService> _userHelper;
     private readonly Mock<IMediator> _mediatorMock;
     private readonly ChangedController _controller;
-    private readonly IOptions<AodpConfiguration> _aodpOptions = Options.Create(new AodpConfiguration
-    {
-        FindRegulatedQualificationUrl = "https://find-a-qualification.services.ofqual.gov.uk/qualifications/"
-    });
 
     public ReviewChangedControllerTests()
     {
@@ -35,7 +31,7 @@ public class ReviewChangedControllerTests
         _userHelper = _fixture.Freeze<Mock<IUserHelperService>>();
         _mediatorMock = _fixture.Freeze<Mock<IMediator>>();
 
-        _controller = new ChangedController(_loggerMock.Object, _aodpOptions, _mediatorMock.Object, _userHelper.Object);
+        _controller = new ChangedController(_loggerMock.Object, _mediatorMock.Object, _userHelper.Object);
 
         _userHelper
             .Setup(u => u.GetUserRoles())

--- a/src/SFA.DAS.AODP.Web.Test/Controllers/ReviewChangedControllerTests.cs
+++ b/src/SFA.DAS.AODP.Web.Test/Controllers/ReviewChangedControllerTests.cs
@@ -77,7 +77,6 @@ public class ReviewChangedControllerTests
         // Assert
         var viewResult = Assert.IsType<ViewResult>(result);
         var model = Assert.IsAssignableFrom<ChangedQualificationsViewModel>(viewResult.ViewData.Model);
-        Assert.Equal(_aodpOptions.Value.FindRegulatedQualificationUrl, model.FindRegulatedQualificationUrl);
     }
 
     [Fact]
@@ -112,7 +111,6 @@ public class ReviewChangedControllerTests
         Assert.Equal(queryResponse.Value.Data[0].Status, model.ChangedQualifications[0].Status);
         Assert.Equal(queryResponse.Value.Data[0].AwardingOrganisation, model.ChangedQualifications[0].AwardingOrganisation);
         Assert.Equal(queryResponse.Value.Data[0].Status, model.ChangedQualifications[0].Status);
-        Assert.Equal(_aodpOptions.Value.FindRegulatedQualificationUrl, model.FindRegulatedQualificationUrl);
     }
 
     [Fact]

--- a/src/SFA.DAS.AODP.Web.Test/TagHelpers/OfqualRegisterExternalLinkTagHelperUnitTests.cs
+++ b/src/SFA.DAS.AODP.Web.Test/TagHelpers/OfqualRegisterExternalLinkTagHelperUnitTests.cs
@@ -63,6 +63,34 @@ public class OfqualRegisterExternalLinkTagHelperUnitTests : TagHelpersUnitTestBa
     }
 
     [Fact]
+    public async Task Process_SuccessfullyRenderHtml_OpenInNamedTabTrue()
+    {
+        // Arrange
+        var tagHelper = new OfqualRegisterExternalLinkTagHelper(Options.Create(new AodpConfiguration
+        {
+            FindRegulatedQualificationUrl = "https://find-a-qualification.services.ofqual.gov.uk/qualifications/",
+        }))
+        {
+            QualificationReference = "12345",
+            OpensInNamedTab = true
+        };
+
+        var tagHelperContext = GenerateTagHelperContext(OfqualRegisterExternalLinkTagHelper.TagName);
+        var tagHelperOutput = GenerateTagHelperOutput(OfqualRegisterExternalLinkTagHelper.TagName, []);
+
+        // Act
+        await tagHelper.ProcessAsync(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        var writer = new StringWriter();
+        tagHelperOutput.WriteTo(writer, HtmlEncoder.Default);
+
+        var html = writer.ToString();
+
+        Assert.Equal("<a class=\"govuk-link\" target=\"12345\" href=\"https://find-a-qualification.services.ofqual.gov.uk/qualifications/12345\">12345</a>", html);
+    }
+
+    [Fact]
     public async Task Process_QualificationReferenceNotPassed_ThrowNullReferenceException()
     {
         // Arrange
@@ -75,7 +103,7 @@ public class OfqualRegisterExternalLinkTagHelperUnitTests : TagHelpersUnitTestBa
         var tagHelperOutput = GenerateTagHelperOutput(OfqualRegisterExternalLinkTagHelper.TagName, []);
 
         // Act
-        await Assert.ThrowsAsync<NullReferenceException>(() => tagHelper.ProcessAsync(tagHelperContext, tagHelperOutput));
+        await Assert.ThrowsAsync<TagHelperRenderingException>(() => tagHelper.ProcessAsync(tagHelperContext, tagHelperOutput));
     }
 
     [Fact]
@@ -91,6 +119,6 @@ public class OfqualRegisterExternalLinkTagHelperUnitTests : TagHelpersUnitTestBa
         var tagHelperOutput = GenerateTagHelperOutput(OfqualRegisterExternalLinkTagHelper.TagName, []);
 
         // Act
-        await Assert.ThrowsAsync<NullReferenceException>(() => tagHelper.ProcessAsync(tagHelperContext, tagHelperOutput));
+        await Assert.ThrowsAsync<TagHelperRenderingException>(() => tagHelper.ProcessAsync(tagHelperContext, tagHelperOutput));
     }
 }

--- a/src/SFA.DAS.AODP.Web.Test/TagHelpers/OfqualRegisterExternalLinkTagHelperUnitTests.cs
+++ b/src/SFA.DAS.AODP.Web.Test/TagHelpers/OfqualRegisterExternalLinkTagHelperUnitTests.cs
@@ -1,0 +1,96 @@
+﻿using System.Text.Encodings.Web;
+using Microsoft.Extensions.Options;
+using SFA.DAS.AODP.Models.Settings;
+using SFA.DAS.AODP.Web.TagHelpers;
+
+namespace SFA.DAS.AODP.Web.UnitTests.TagHelpers;
+
+public class OfqualRegisterExternalLinkTagHelperUnitTests : TagHelpersUnitTestBase
+{
+    [Fact]
+    public async Task Process_SuccessfullyRenderHtml()
+    {
+        // Arrange
+        var tagHelper = new OfqualRegisterExternalLinkTagHelper(Options.Create(new AodpConfiguration
+        {
+            FindRegulatedQualificationUrl = "https://find-a-qualification.services.ofqual.gov.uk/qualifications/",
+        }))
+        {
+            QualificationReference = "12345"
+        };
+
+        var tagHelperContext = GenerateTagHelperContext(OfqualRegisterExternalLinkTagHelper.TagName);
+        var tagHelperOutput = GenerateTagHelperOutput(OfqualRegisterExternalLinkTagHelper.TagName, []);
+
+        // Act
+        await tagHelper.ProcessAsync(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        var writer = new StringWriter();
+        tagHelperOutput.WriteTo(writer, HtmlEncoder.Default);
+
+        var html = writer.ToString();
+
+        Assert.Equal("<a class=\"govuk-link\" target=\"12345\" href=\"https://find-a-qualification.services.ofqual.gov.uk/qualifications/12345\">12345</a>", html);
+    }
+
+    [Fact]
+    public async Task Process_SuccessfullyRenderHtml_OpenInNamedTabFalse()
+    {
+        // Arrange
+        var tagHelper = new OfqualRegisterExternalLinkTagHelper(Options.Create(new AodpConfiguration
+        {
+            FindRegulatedQualificationUrl = "https://find-a-qualification.services.ofqual.gov.uk/qualifications/",
+        }))
+        {
+            QualificationReference = "12345",
+            OpensInNamedTab = false
+        };
+
+        var tagHelperContext = GenerateTagHelperContext(OfqualRegisterExternalLinkTagHelper.TagName);
+        var tagHelperOutput = GenerateTagHelperOutput(OfqualRegisterExternalLinkTagHelper.TagName, []);
+
+        // Act
+        await tagHelper.ProcessAsync(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        var writer = new StringWriter();
+        tagHelperOutput.WriteTo(writer, HtmlEncoder.Default);
+
+        var html = writer.ToString();
+
+        Assert.Equal("<a class=\"govuk-link\" target=\"_blank\" href=\"https://find-a-qualification.services.ofqual.gov.uk/qualifications/12345\">12345</a>", html);
+    }
+
+    [Fact]
+    public async Task Process_QualificationReferenceNotPassed_ThrowNullReferenceException()
+    {
+        // Arrange
+        var tagHelper = new OfqualRegisterExternalLinkTagHelper(Options.Create(new AodpConfiguration
+        {
+            FindRegulatedQualificationUrl = "https://find-a-qualification.services.ofqual.gov.uk/qualifications/",
+        }));
+
+        var tagHelperContext = GenerateTagHelperContext(OfqualRegisterExternalLinkTagHelper.TagName);
+        var tagHelperOutput = GenerateTagHelperOutput(OfqualRegisterExternalLinkTagHelper.TagName, []);
+
+        // Act
+        await Assert.ThrowsAsync<NullReferenceException>(() => tagHelper.ProcessAsync(tagHelperContext, tagHelperOutput));
+    }
+
+    [Fact]
+    public async Task Process_ConfigNotSet_ThrowNullReferenceException()
+    {
+        // Arrange
+        var tagHelper = new OfqualRegisterExternalLinkTagHelper(Options.Create(new AodpConfiguration
+        {
+            FindRegulatedQualificationUrl = string.Empty!,
+        }));
+
+        var tagHelperContext = GenerateTagHelperContext(OfqualRegisterExternalLinkTagHelper.TagName);
+        var tagHelperOutput = GenerateTagHelperOutput(OfqualRegisterExternalLinkTagHelper.TagName, []);
+
+        // Act
+        await Assert.ThrowsAsync<NullReferenceException>(() => tagHelper.ProcessAsync(tagHelperContext, tagHelperOutput));
+    }
+}

--- a/src/SFA.DAS.AODP.Web.Test/TagHelpers/OfqualRegisterExternalLinkTagHelperUnitTests.cs
+++ b/src/SFA.DAS.AODP.Web.Test/TagHelpers/OfqualRegisterExternalLinkTagHelperUnitTests.cs
@@ -59,6 +59,7 @@ public class OfqualRegisterExternalLinkTagHelperUnitTests : TagHelpersUnitTestBa
 
         var html = writer.ToString();
 
+        Assert.Equal("_blank", tagHelperOutput.Attributes["target"].Value.ToString());
         Assert.Equal("<a class=\"govuk-link\" target=\"_blank\" href=\"https://find-a-qualification.services.ofqual.gov.uk/qualifications/12345\">12345</a>", html);
     }
 
@@ -87,11 +88,12 @@ public class OfqualRegisterExternalLinkTagHelperUnitTests : TagHelpersUnitTestBa
 
         var html = writer.ToString();
 
+        Assert.Equal("12345", tagHelperOutput.Attributes["target"].Value.ToString());
         Assert.Equal("<a class=\"govuk-link\" target=\"12345\" href=\"https://find-a-qualification.services.ofqual.gov.uk/qualifications/12345\">12345</a>", html);
     }
 
     [Fact]
-    public async Task Process_QualificationReferenceNotPassed_ThrowNullReferenceException()
+    public async Task Process_QualificationReferenceNotPassed_ThrowException()
     {
         // Arrange
         var tagHelper = new OfqualRegisterExternalLinkTagHelper(Options.Create(new AodpConfiguration
@@ -106,13 +108,15 @@ public class OfqualRegisterExternalLinkTagHelperUnitTests : TagHelpersUnitTestBa
         await Assert.ThrowsAsync<TagHelperRenderingException>(() => tagHelper.ProcessAsync(tagHelperContext, tagHelperOutput));
     }
 
-    [Fact]
-    public async Task Process_ConfigNotSet_ThrowNullReferenceException()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task Process_ConfigNotSet_ThrowException(string? url)
     {
         // Arrange
         var tagHelper = new OfqualRegisterExternalLinkTagHelper(Options.Create(new AodpConfiguration
         {
-            FindRegulatedQualificationUrl = string.Empty!,
+            FindRegulatedQualificationUrl = url!,
         }));
 
         var tagHelperContext = GenerateTagHelperContext(OfqualRegisterExternalLinkTagHelper.TagName);

--- a/src/SFA.DAS.AODP.Web.Test/TagHelpers/TagHelpersUnitTestBase.cs
+++ b/src/SFA.DAS.AODP.Web.Test/TagHelpers/TagHelpersUnitTestBase.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+
+namespace SFA.DAS.AODP.Web.UnitTests.TagHelpers;
+
+public class TagHelpersUnitTestBase
+{
+    protected Mock<IModelMetadataProvider> MockModelMetaDataProvider = new();
+
+    protected Mock<ModelMetadata> MockModelMetadata { get; set; } = null!;
+
+    protected void SetModelMetadata<T>() => MockModelMetadata = new Mock<ModelMetadata>(ModelMetadataIdentity.ForType(typeof(T)));
+
+    protected static TagHelperContext GenerateTagHelperContext(string tagName, string uniqueId = "test")
+        => new(
+            tagName: tagName,
+            allAttributes: new TagHelperAttributeList(),
+            items: new Dictionary<object, object>(),
+            uniqueId: "test");
+
+    protected static TagHelperOutput GenerateTagHelperOutput(string tagName, TagHelperAttributeList attributes)
+        => new(
+            tagName,
+            attributes: attributes,
+            getChildContentAsync: (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+
+    protected static ViewContext CreateDefaultViewContext()
+    {
+        var actionContext = new ActionContext(
+            new DefaultHttpContext(),
+            new RouteData(),
+            new ActionDescriptor());
+
+        return new ViewContext(
+            actionContext,
+            Mock.Of<IView>(),
+            new ViewDataDictionary(
+                new EmptyModelMetadataProvider(),
+                new ModelStateDictionary()),
+            Mock.Of<ITempDataDictionary>(),
+            TextWriter.Null,
+            new HtmlHelperOptions());
+    }
+}

--- a/src/SFA.DAS.AODP.Web/Areas/Admin/Views/_ViewImports.cshtml
+++ b/src/SFA.DAS.AODP.Web/Areas/Admin/Views/_ViewImports.cshtml
@@ -13,3 +13,4 @@
 @using SFA.DAS.AODP.Application.Queries.FormBuilder.Pages;
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, GovUk.Frontend.AspNetCore
+@addTagHelper *, SFA.DAS.AODP.Web

--- a/src/SFA.DAS.AODP.Web/Areas/Apply/Views/_ViewImports.cshtml
+++ b/src/SFA.DAS.AODP.Web/Areas/Apply/Views/_ViewImports.cshtml
@@ -8,3 +8,4 @@
 @using SFA.DAS.AODP.Application.Queries.FormBuilder.Pages;
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, GovUk.Frontend.AspNetCore
+@addTagHelper *, SFA.DAS.AODP.Web

--- a/src/SFA.DAS.AODP.Web/Areas/Review/Controllers/ChangedController.cs
+++ b/src/SFA.DAS.AODP.Web/Areas/Review/Controllers/ChangedController.cs
@@ -33,7 +33,6 @@ namespace SFA.DAS.AODP.Web.Areas.Review.Controllers
         private readonly ILogger<ChangedController> _logger;
         private readonly IMediator _mediator;
         private readonly IUserHelperService _userHelperService;
-        private readonly IOptions<AodpConfiguration> _aodpConfiguration;
 
         private List<string> ReviewerAllowedStatuses { get; set; } =
         [
@@ -50,10 +49,9 @@ namespace SFA.DAS.AODP.Web.Areas.Review.Controllers
 
         public enum NewQualDataKeys { InvalidPageParams, CommentSaved}
 
-        public ChangedController(ILogger<ChangedController> logger, IOptions<AodpConfiguration> configuration, IMediator mediator, IUserHelperService userHelperService) : base(mediator, logger)
+        public ChangedController(ILogger<ChangedController> logger, IMediator mediator, IUserHelperService userHelperService) : base(mediator, logger)
         {
             _logger = logger;
-            _aodpConfiguration = configuration;
             _mediator = mediator;
             this._userHelperService = userHelperService;
         }

--- a/src/SFA.DAS.AODP.Web/Areas/Review/Controllers/ChangedController.cs
+++ b/src/SFA.DAS.AODP.Web/Areas/Review/Controllers/ChangedController.cs
@@ -503,7 +503,6 @@ namespace SFA.DAS.AODP.Web.Areas.Review.Controllers
 
             vm.ProcessStatuses = [.. statuses];
             vm.SetBulkActionStatusOptions(statuses.Select(s => (s.Id, s.Name ?? "")));
-            vm.FindRegulatedQualificationUrl = _aodpConfiguration.Value.FindRegulatedQualificationUrl;
 
             if (postedModel != null)
             {

--- a/src/SFA.DAS.AODP.Web/Areas/Review/Controllers/NewController.cs
+++ b/src/SFA.DAS.AODP.Web/Areas/Review/Controllers/NewController.cs
@@ -434,8 +434,6 @@ namespace SFA.DAS.AODP.Web.Areas.Review.Controllers
                 vm = new NewQualificationsViewModel();
             }
 
-            vm.FindRegulatedQualificationUrl = _aodpConfiguration.Value.FindRegulatedQualificationUrl;
-
             vm.Filter = qualificationQuery.ToQualificationFilterViewModel();
 
             vm.ProcessStatuses = [.. statuses];

--- a/src/SFA.DAS.AODP.Web/Areas/Review/Controllers/NewController.cs
+++ b/src/SFA.DAS.AODP.Web/Areas/Review/Controllers/NewController.cs
@@ -30,7 +30,6 @@ namespace SFA.DAS.AODP.Web.Areas.Review.Controllers
         private readonly ILogger<NewController> _logger;
         private readonly IMediator _mediator;
         private readonly IUserHelperService _userHelperService;
-        private readonly IOptions<AodpConfiguration> _aodpConfiguration;
         private List<string> ReviewerAllowedStatuses { get; set; } = new List<string>()
         {
             ProcessStatus.DecisionRequired,
@@ -38,12 +37,11 @@ namespace SFA.DAS.AODP.Web.Areas.Review.Controllers
         };
         public enum NewQualDataKeys { InvalidPageParams, CommentSaved}
 
-        public NewController(ILogger<NewController> logger, IOptions<AodpConfiguration> configuration, IMediator mediator, IUserHelperService userHelperService) : base(mediator, logger)
+        public NewController(ILogger<NewController> logger, IMediator mediator, IUserHelperService userHelperService) : base(mediator, logger)
         {
             _logger = logger;
             _mediator = mediator;
             _userHelperService = userHelperService;
-            _aodpConfiguration = configuration;
         }
 
         [Route("/Review/New/Index")]

--- a/src/SFA.DAS.AODP.Web/Areas/Review/Views/Changed/Index.cshtml
+++ b/src/SFA.DAS.AODP.Web/Areas/Review/Views/Changed/Index.cshtml
@@ -202,9 +202,7 @@
                                                     <td class="govuk-table__cell">
                                                         @if (!string.IsNullOrWhiteSpace(qualification.QualificationReference))
                                                         {
-                                                            var baseUrl = Model.FindRegulatedQualificationUrl ?? string.Empty;
-                                                            var fullUrl = $"{baseUrl}{qualification.QualificationReference}";
-                                                            <a href="@fullUrl" target="_blank">@qualification.QualificationReference</a>
+                                                            <ofqual-register qualification-reference="@qualification.QualificationReference" />
                                                         }
                                                     </td>
                                                     <td class="govuk-table__cell">

--- a/src/SFA.DAS.AODP.Web/Areas/Review/Views/New/Index.cshtml
+++ b/src/SFA.DAS.AODP.Web/Areas/Review/Views/New/Index.cshtml
@@ -191,9 +191,7 @@
                                                 <td class="govuk-table__cell">
                                                     @if (!string.IsNullOrWhiteSpace(qualification.Reference))
                                                     {
-                                                        var baseUrl = Model.FindRegulatedQualificationUrl ?? string.Empty;
-                                                        var fullUrl = $"{baseUrl}{qualification.Reference}";
-                                                        <a href="@fullUrl" target="_blank">@qualification.Reference</a>
+                                                        <ofqual-register qualification-reference="@qualification.Reference" />
                                                     }
                                                 </td>
                                                 <td class="govuk-table__cell">

--- a/src/SFA.DAS.AODP.Web/Areas/Review/Views/QualificationSearch/Index.cshtml
+++ b/src/SFA.DAS.AODP.Web/Areas/Review/Views/QualificationSearch/Index.cshtml
@@ -68,7 +68,9 @@
                         {
 
                             <tr class="govuk-table__row">
-                                <td class="govuk-table__cell">@qualification.Qan</td>
+                                <td class="govuk-table__cell">
+                                    <ofqual-register qualification-reference="@qualification.Qan" />
+                                </td>
                                 <td class="govuk-table__cell">
                                     <a class="govuk-link" href="@Url.Action("QualificationDetails", "New", new { area = "Review", qualificationReference = qualification.Qan, returnTo = "QualificationSearch" })">
                                         @qualification.QualificationName

--- a/src/SFA.DAS.AODP.Web/Areas/Review/Views/_ViewImports.cshtml
+++ b/src/SFA.DAS.AODP.Web/Areas/Review/Views/_ViewImports.cshtml
@@ -8,3 +8,4 @@
 @using SFA.DAS.AODP.Application.Queries.FormBuilder.Pages;
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, GovUk.Frontend.AspNetCore
+@addTagHelper *, SFA.DAS.AODP.Web

--- a/src/SFA.DAS.AODP.Web/GlobalUsings.cs
+++ b/src/SFA.DAS.AODP.Web/GlobalUsings.cs
@@ -1,0 +1,6 @@
+﻿global using Microsoft.AspNetCore.Razor.TagHelpers;
+global using Microsoft.Extensions.Options;
+
+global using SFA.DAS.AODP.Models.Settings;
+
+global using System.Diagnostics.CodeAnalysis;

--- a/src/SFA.DAS.AODP.Web/Models/Qualifications/ChangedQualificationsViewModel .cs
+++ b/src/SFA.DAS.AODP.Web/Models/Qualifications/ChangedQualificationsViewModel .cs
@@ -23,7 +23,6 @@ namespace SFA.DAS.AODP.Web.Models.Qualifications
         public JobStatusViewModel JobStatusViewModel { get; set; }
 
         public List<ProcessStatus> ProcessStatuses { get; set; } = new List<ProcessStatus>();
-        public string FindRegulatedQualificationUrl { get; set; } = string.Empty;
 
         public class ProcessStatus
         {

--- a/src/SFA.DAS.AODP.Web/Models/Qualifications/NewQualificationsViewModel.cs
+++ b/src/SFA.DAS.AODP.Web/Models/Qualifications/NewQualificationsViewModel.cs
@@ -28,7 +28,6 @@ namespace SFA.DAS.AODP.Web.Models.Qualifications
         public JobStatusViewModel JobStatusViewModel { get; set; }
         public List<ProcessStatus> ProcessStatuses { get; set; } = new List<ProcessStatus>();
 
-        public string FindRegulatedQualificationUrl { get; set; } = string.Empty;
         public class ProcessStatus
         {
             public Guid Id { get; set; }

--- a/src/SFA.DAS.AODP.Web/SFA.DAS.AODP.Web.csproj
+++ b/src/SFA.DAS.AODP.Web/SFA.DAS.AODP.Web.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
+	<PropertyGroup>
+		<AssemblyName>SFA.DAS.AODP.Web</AssemblyName>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<Compile Remove="Areas\Funding\Data\**" />
 		<Compile Remove="Areas\Funding\Models\**" />

--- a/src/SFA.DAS.AODP.Web/TagHelpers/OfqualRegisterExternalLinkTagHelper.cs
+++ b/src/SFA.DAS.AODP.Web/TagHelpers/OfqualRegisterExternalLinkTagHelper.cs
@@ -1,8 +1,4 @@
-﻿using Microsoft.AspNetCore.Razor.TagHelpers;
-using Microsoft.Extensions.Options;
-using SFA.DAS.AODP.Models.Settings;
-
-namespace SFA.DAS.AODP.Web.TagHelpers;
+﻿namespace SFA.DAS.AODP.Web.TagHelpers;
 
 /// <summary>
 /// Defines a TagHelper that renders an anchor tag with GDS styling, linking to the Ofqual Register for a specified qualification reference.

--- a/src/SFA.DAS.AODP.Web/TagHelpers/OfqualRegisterExternalLinkTagHelper.cs
+++ b/src/SFA.DAS.AODP.Web/TagHelpers/OfqualRegisterExternalLinkTagHelper.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Options;
+using SFA.DAS.AODP.Models.Settings;
+
+namespace SFA.DAS.AODP.Web.TagHelpers;
+
+/// <summary>
+/// Defines a TagHelper that renders an anchor tag with GDS styling, linking to the Ofqual Register for a specified qualification reference.
+/// The link can be configured to open in a named tab or a new tab based on the 'opens-in-named-tab' attribute.
+/// </summary>
+[HtmlTargetElement(TagName, Attributes = "qualification-reference")]
+public class OfqualRegisterExternalLinkTagHelper(IOptions<AodpConfiguration> aodpConfiguration) : TagHelper
+{
+    private readonly AodpConfiguration _aodpConfiguration = aodpConfiguration.Value;
+    public const string TagName = "ofqual-register";
+
+    /// <summary>
+    /// The qualification reference to link to on the Ofqual Register. This attribute is required and must not be empty.
+    /// </summary>
+    [HtmlAttributeName("qualification-reference")]
+    public string QualificationReference { get; set; } = null!;
+
+    /// <summary>
+    /// Determines whether the link should open in a named tab (using the qualification reference as the target) or in a new tab (using "_blank" as the target).
+    /// </summary>
+    [HtmlAttributeName("opens-in-named-tab")]
+    public bool OpensInNamedTab { get; set; } = true;
+
+    /// <inheritdoc/>
+    public override Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        base.ProcessAsync(context, output);
+
+        output.TagName = "a";
+        output.TagMode = TagMode.StartTagAndEndTag;
+
+        output.Attributes.SetAttribute("class", "govuk-link");
+
+        if (string.IsNullOrEmpty(QualificationReference))
+        {
+            throw new NullReferenceException("The 'qualification-reference' attribute must be provided and cannot be empty.");
+        }
+
+        if (OpensInNamedTab)
+        {
+            output.Attributes.SetAttribute("target", $"{QualificationReference}");
+        }
+        else
+        {
+            output.Attributes.SetAttribute("target", "_blank");
+        }
+
+        if (string.IsNullOrEmpty(_aodpConfiguration.FindRegulatedQualificationUrl))
+        {
+            throw new NullReferenceException("The 'FindRegulatedQualificationUrl' configuration value must be provided and cannot be empty.");
+        }
+
+        output.Attributes.SetAttribute("href", $"{_aodpConfiguration.FindRegulatedQualificationUrl}{QualificationReference}");
+        output.Content.SetContent(QualificationReference);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/SFA.DAS.AODP.Web/TagHelpers/OfqualRegisterExternalLinkTagHelper.cs
+++ b/src/SFA.DAS.AODP.Web/TagHelpers/OfqualRegisterExternalLinkTagHelper.cs
@@ -38,7 +38,7 @@ public class OfqualRegisterExternalLinkTagHelper(IOptions<AodpConfiguration> aod
 
         if (string.IsNullOrEmpty(QualificationReference))
         {
-            throw new NullReferenceException("The 'qualification-reference' attribute must be provided and cannot be empty.");
+            throw new TagHelperRenderingException(nameof(OfqualRegisterExternalLinkTagHelper), "The 'qualification-reference' attribute must be provided and cannot be empty.");
         }
 
         if (OpensInNamedTab)
@@ -52,7 +52,7 @@ public class OfqualRegisterExternalLinkTagHelper(IOptions<AodpConfiguration> aod
 
         if (string.IsNullOrEmpty(_aodpConfiguration.FindRegulatedQualificationUrl))
         {
-            throw new NullReferenceException("The 'FindRegulatedQualificationUrl' configuration value must be provided and cannot be empty.");
+            throw new TagHelperRenderingException(nameof(OfqualRegisterExternalLinkTagHelper), "The 'FindRegulatedQualificationUrl' configuration value must be provided and cannot be empty.");
         }
 
         output.Attributes.SetAttribute("href", $"{_aodpConfiguration.FindRegulatedQualificationUrl}{QualificationReference}");

--- a/src/SFA.DAS.AODP.Web/TagHelpers/TagHelperRenderingException.cs
+++ b/src/SFA.DAS.AODP.Web/TagHelpers/TagHelperRenderingException.cs
@@ -1,0 +1,6 @@
+﻿namespace SFA.DAS.AODP.Web.TagHelpers;
+
+public class TagHelperRenderingException(string tagHelperName, string message)
+    : Exception($"An error occurred in the '{tagHelperName}' tag helper: {message}")
+{
+}

--- a/src/SFA.DAS.AODP.Web/TagHelpers/TagHelperRenderingException.cs
+++ b/src/SFA.DAS.AODP.Web/TagHelpers/TagHelperRenderingException.cs
@@ -1,5 +1,12 @@
 ﻿namespace SFA.DAS.AODP.Web.TagHelpers;
 
+/// <summary>
+/// Defines a custom exception type for errors that occur during the rendering of TagHelpers. This exception can be used to provide more specific error messages related to TagHelper processing,
+/// making it easier to identify and troubleshoot issues in the Razor views where TagHelpers are used.
+/// </summary>
+/// <param name="tagHelperName">The name of the TagHelper where the error occurred.</param>
+/// <param name="message">The error message describing the issue.</param>
+[ExcludeFromCodeCoverage]
 public class TagHelperRenderingException(string tagHelperName, string message)
     : Exception($"An error occurred in the '{tagHelperName}' tag helper: {message}")
 {

--- a/src/SFA.DAS.AODP.Web/Views/_ViewImports.cshtml
+++ b/src/SFA.DAS.AODP.Web/Views/_ViewImports.cshtml
@@ -13,3 +13,4 @@
 @using SFA.DAS.AODP.Application.Queries.FormBuilder.Pages;
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, GovUk.Frontend.AspNetCore
+@addTagHelper *, SFA.DAS.AODP.Web


### PR DESCRIPTION
- [AWARD-1151] - Added new tag helper which outputs an anchor tag complete with GDS styling and functionality to link to the ofqual register for a given qualification reference number (QAN)

[AWARD-1151]: https://skillsfundingagency.atlassian.net/browse/AWARD-1151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ