### PR TITLE
[AWARD-1223] - Obfuscate internal user name from application messages on the AO side.

### DIFF
--- a/src/SFA.DAS.AODP.Web.Test/Areas/Apply/Models/ApplicationMessageViewModelTests.cs
+++ b/src/SFA.DAS.AODP.Web.Test/Areas/Apply/Models/ApplicationMessageViewModelTests.cs
@@ -1,0 +1,106 @@
+﻿using SFA.DAS.AODP.Web.Enums;
+using SFA.DAS.AODP.Web.Areas.Apply.Models;
+
+namespace SFA.DAS.AODP.Web.UnitTests.Areas.Apply.Models;
+
+public class ApplicationMessageViewModelTests : UnitTest
+{
+    [Fact]
+    public void TimelineTitle_ShouldReturnMessageHeader()
+    {
+        // Arrange
+        var sut = CreateViewModel(messageHeader: "Application unlocked");
+
+        // Act
+        var result = sut.TimelineTitle;
+
+        // Assert
+        result.ShouldBe("Application unlocked");
+    }
+
+    [Fact]
+    public void TimelineMetadata_ShouldReturnQfauWithFormattedSentAt()
+    {
+        // Arrange
+        var sut = CreateViewModel(
+            sentAt: new DateTime(2026, 6, 12, 14, 5, 0));
+
+        // Act
+        var result = sut.TimelineMetadata;
+
+        // Assert
+        result.ShouldBe("Qualification Funding Approval Unit, 12 Jun 2026 at 14:05");
+    }
+
+    [Theory]
+    [InlineData("Some message text", true)]
+    [InlineData("", false)]
+    [InlineData(" ", true)]
+    public void ShowText_ShouldReturnWhetherTextHasAnyCharacters(
+        string text,
+        bool expectedResult)
+    {
+        // Arrange
+        var sut = CreateViewModel(text: text);
+
+        // Act
+        var result = sut.ShowText;
+
+        // Assert
+        result.ShouldBe(expectedResult);
+    }
+
+    [Fact]
+    public void MessageTypeConfiguration_ShouldReturnConfigurationForMessageType()
+    {
+        // Arrange
+        var messageType = MessageType.InternalNotes;
+
+        var expectedConfiguration = MessageTypeConfigurationRules
+            .GetMessageSharingSettings(messageType.ToString());
+
+        var sut = CreateViewModel(messageType: messageType.ToString());
+
+        // Act
+        var result = sut.MessageTypeConfiguration;
+
+        // Assert
+        result.DisplayName.ShouldBe(expectedConfiguration.DisplayName);
+        result.MessageInformationBanner.ShouldBe(expectedConfiguration.MessageInformationBanner);
+    }
+
+    [Fact]
+    public void MessageTypeDisplay_ShouldReturnDisplayNameFromMessageTypeConfiguration()
+    {
+        // Arrange
+        var messageType = MessageType.InternalNotesForPartners;
+
+        var expectedDisplayName = MessageTypeConfigurationRules
+            .GetMessageSharingSettings(messageType.ToString())
+            .DisplayName;
+
+        var sut = CreateViewModel(messageType: messageType.ToString());
+
+        // Act
+        var result = sut.MessageTypeDisplay;
+
+        // Assert
+        result.ShouldBe(expectedDisplayName);
+    }
+
+    private static ApplicationMessageViewModel CreateViewModel(
+        string? messageHeader = null,
+        string? text = null,
+        DateTime? sentAt = null,
+        string? messageType = null) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            MessageHeader = messageHeader ?? "Test message header",
+            Text = text ?? "Test message text",
+            SentAt = sentAt ?? new DateTime(2026, 6, 12, 14, 5, 0),
+            SentByName = "Test User",
+            SentByEmail = "test@example.com",
+            MessageType = messageType ?? nameof(MessageType.InternalNotes)
+        };
+}

--- a/src/SFA.DAS.AODP.Web.Test/Areas/Apply/Models/ApplicationMessageViewModelTests.cs
+++ b/src/SFA.DAS.AODP.Web.Test/Areas/Apply/Models/ApplicationMessageViewModelTests.cs
@@ -19,17 +19,35 @@ public class ApplicationMessageViewModelTests : UnitTest
     }
 
     [Fact]
-    public void TimelineMetadata_ShouldReturnQfauWithFormattedSentAt()
+    public void TimelineMetadata_WhenSentByStaff_ShouldReturnQfauWithFormattedSentAt()
     {
         // Arrange
         var sut = CreateViewModel(
-            sentAt: new DateTime(2026, 6, 12, 14, 5, 0));
+            sentAt: new DateTime(2026, 6, 12, 14, 5, 0),
+            messageType: nameof(MessageType.InternalNotes));
 
         // Act
         var result = sut.TimelineMetadata;
 
         // Assert
         result.ShouldBe("Qualification Funding Approval Unit, 12 Jun 2026 at 14:05");
+    }
+
+    [Theory]
+    [InlineData(nameof(MessageType.ReplyToInformationRequest))]
+    [InlineData(nameof(MessageType.ApplicationSubmitted))]
+    public void TimelineMetadata_WhenSentByAwardingOrganisation_ShouldReturnSentByNameWithFormattedSentAt(string messageType)
+    {
+        // Arrange
+        var sut = CreateViewModel(
+            sentAt: new DateTime(2026, 6, 12, 14, 5, 0),
+            messageType: messageType);
+
+        // Act
+        var result = sut.TimelineMetadata;
+
+        // Assert
+        result.ShouldBe("Test User, 12 Jun 2026 at 14:05");
     }
 
     [Theory]

--- a/src/SFA.DAS.AODP.Web.Test/Areas/Review/Models/ApplicationMessage/ApplicationMessageViewModelTests.cs
+++ b/src/SFA.DAS.AODP.Web.Test/Areas/Review/Models/ApplicationMessage/ApplicationMessageViewModelTests.cs
@@ -1,0 +1,41 @@
+using SFA.DAS.AODP.Web.Enums;
+using SFA.DAS.AODP.Web.Areas.Review.Models.ApplicationMessage;
+
+namespace SFA.DAS.AODP.Web.UnitTests.Areas.Review.Models.ApplicationMessage;
+
+public class ApplicationMessageViewModelTests : UnitTest
+{
+    [Theory]
+    [InlineData(nameof(MessageType.InternalNotes))]
+    [InlineData(nameof(MessageType.ReplyToInformationRequest))]
+    [InlineData(nameof(MessageType.ApplicationSubmitted))]
+    public void TimelineMetadata_ShouldAlwaysReturnSentByNameRegardlessOfMessageType(string messageType)
+    {
+        // Arrange
+        var sut = CreateViewModel(
+            sentAt: new DateTime(2026, 6, 12, 14, 5, 0),
+            messageType: messageType);
+
+        // Act
+        var result = sut.TimelineMetadata;
+
+        // Assert
+        result.ShouldBe("Test User, 12 Jun 2026 at 14:05");
+    }
+
+    private static ApplicationMessageViewModel CreateViewModel(
+        string? messageHeader = null,
+        string? text = null,
+        DateTime? sentAt = null,
+        string? messageType = null) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            MessageHeader = messageHeader ?? "Test message header",
+            Text = text ?? "Test message text",
+            SentAt = sentAt ?? new DateTime(2026, 6, 12, 14, 5, 0),
+            SentByName = "Test User",
+            SentByEmail = "test@example.com",
+            MessageType = messageType ?? nameof(MessageType.InternalNotes)
+        };
+}

--- a/src/SFA.DAS.AODP.Web/Areas/Apply/Models/ApplicationMessagesViewModel.cs
+++ b/src/SFA.DAS.AODP.Web/Areas/Apply/Models/ApplicationMessagesViewModel.cs
@@ -64,24 +64,12 @@ public class ApplicationMessagesViewModel : IHasRelatedLinks
 
 public class ApplicationMessageViewModel : TimelineItemBase
 {
-    public string MessageType { get; set; }
+    public string MessageType { get; set; } = null!;
     public UserType UserType { get; set; }
     public MessageTypeConfiguration MessageTypeConfiguration => MessageTypeConfigurationRules.GetMessageSharingSettings(MessageType);
     public string MessageTypeDisplay => MessageTypeConfiguration.DisplayName;
-    public string SentByEmail { get; set; }
+    public string SentByEmail { get; set; } = null!;
     public override string TimelineTitle => $"{MessageHeader}";
-    public override string TimelineMetadata
-    {
-        get
-        {
-            return $"{SentByName}, {SentAt.ToString("dd MMM yyyy 'at' HH:mm", CultureInfo.InvariantCulture)}";
-        }
-    }
-    public override bool ShowText
-    {
-        get
-        {
-            return (Text.Length > 0) ? true : false;
-        }
-    }
+    public override string TimelineMetadata => $"Qualification Funding Approval Unit, {SentAt.ToString("dd MMM yyyy 'at' HH:mm", CultureInfo.InvariantCulture)}";
+    public override bool ShowText => Text.Length > 0;
 }

--- a/src/SFA.DAS.AODP.Web/Areas/Apply/Models/ApplicationMessagesViewModel.cs
+++ b/src/SFA.DAS.AODP.Web/Areas/Apply/Models/ApplicationMessagesViewModel.cs
@@ -70,6 +70,15 @@ public class ApplicationMessageViewModel : TimelineItemBase
     public string MessageTypeDisplay => MessageTypeConfiguration.DisplayName;
     public string SentByEmail { get; set; } = null!;
     public override string TimelineTitle => $"{MessageHeader}";
-    public override string TimelineMetadata => $"Qualification Funding Approval Unit, {SentAt.ToString("dd MMM yyyy 'at' HH:mm", CultureInfo.InvariantCulture)}";
+    public override string TimelineMetadata
+    {
+        get
+        {
+            var formattedSentAt = SentAt.ToString("dd MMM yyyy 'at' HH:mm", CultureInfo.InvariantCulture);
+            return MessageTypeConfiguration.SentByAwardingOrganisation
+                ? $"{SentByName}, {formattedSentAt}"
+                : $"Qualification Funding Approval Unit, {formattedSentAt}";
+        }
+    }
     public override bool ShowText => Text.Length > 0;
 }

--- a/src/SFA.DAS.AODP.Web/Enums/MessageType.cs
+++ b/src/SFA.DAS.AODP.Web/Enums/MessageType.cs
@@ -92,6 +92,13 @@ public static class MessageTypeConfigurationRules
             { MessageType.ReplyToInformationRequest, () => new MessageTypeConfiguration
             {
                 DisplayName = "Reply To Information Request",
+                SentByAwardingOrganisation = true,
+            } },
+
+            { MessageType.ApplicationSubmitted, () => new MessageTypeConfiguration
+            {
+                DisplayName = "Application Submitted",
+                SentByAwardingOrganisation = true,
             } }
         };
 
@@ -112,4 +119,5 @@ public class MessageTypeConfiguration
 {
     public string? DisplayName { get; set; }
     public string? MessageInformationBanner { get; set; }
+    public bool SentByAwardingOrganisation { get; set; }
 }


### PR DESCRIPTION
[AWARD-1223]

- For the AO side of the application messages, when a internal QFAU user was adding a note, the individual suers name was being displayed, this has now been obfuscated to show a default 'Qualifications Funding and Approval Unit' and not expose the name

[AWARD-1223]: https://skillsfundingagency.atlassian.net/browse/AWARD-1223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ