### PR TITLE
[AWARD-1241] - Update homepage output file hint text

### DIFF
--- a/src/SFA.DAS.AODP.Web/Areas/Review/Views/Home/Index.cshtml
+++ b/src/SFA.DAS.AODP.Web/Areas/Review/Views/Home/Index.cshtml
@@ -44,7 +44,7 @@
             <h2 class="govuk-heading-s" style="margin-top:1.5rem;">
                 <a asp-area="Admin" asp-controller="OutputFile" asp-action="Index" class="govuk-link">Download an output file</a>
             </h2>
-            <p class="govuk-body">Download a record of all active and archived funding requests.</p>
+            <p class="govuk-body">Download a record of all active and archived funding.</p>
         }
     </div>
 


### PR DESCRIPTION
## Summary

Updated the QFAST homepage hint text under **Download an output file**.

## Changes

- Changed the hint text to: “Download a record of all active and archived funding”
- No layout, styling, or behaviour changes were made.
