### PR TITLE
[AWARD-1240] - Fix issues around request size limits

### DIFF
--- a/src/SFA.DAS.AODP.Application.Tests/Commands/Rollover/SubmitRolloverExtensionCommandHandlerTests.cs
+++ b/src/SFA.DAS.AODP.Application.Tests/Commands/Rollover/SubmitRolloverExtensionCommandHandlerTests.cs
@@ -33,7 +33,7 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             };
 
             _mockApiClient
-                .Setup(c => c.PostWithResponseCodeAsMultipart<SubmitRolloverExtensionCommandResponse>(
+                .Setup(c => c.PostWithResponseCodeAsJsonFile<SubmitRolloverExtensionCommandResponse>(
                     It.IsAny<SubmitRolloverExtensionApiRequest>()))
                 .ReturnsAsync(expectedApiResponse);
 
@@ -47,7 +47,7 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             Assert.Null(result.ErrorMessage);
 
             _mockApiClient.Verify(c =>
-                c.PostWithResponseCodeAsMultipart<SubmitRolloverExtensionCommandResponse>(
+                c.PostWithResponseCodeAsJsonFile<SubmitRolloverExtensionCommandResponse>(
                     It.IsAny<SubmitRolloverExtensionApiRequest>()),
                 Times.Once);
         }
@@ -59,7 +59,7 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             var request = new SubmitRolloverExtensionCommand();
 
             _mockApiClient
-                .Setup(c => c.PostWithResponseCodeAsMultipart<SubmitRolloverExtensionCommandResponse>(
+                .Setup(c => c.PostWithResponseCodeAsJsonFile<SubmitRolloverExtensionCommandResponse>(
                     It.IsAny<SubmitRolloverExtensionApiRequest>()))
                 .ThrowsAsync(new Exception("API failed"));
 
@@ -71,7 +71,7 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             Assert.Equal("API failed", result.ErrorMessage);
 
             _mockApiClient.Verify(c =>
-                c.PostWithResponseCodeAsMultipart<SubmitRolloverExtensionCommandResponse>(
+                c.PostWithResponseCodeAsJsonFile<SubmitRolloverExtensionCommandResponse>(
                     It.IsAny<SubmitRolloverExtensionApiRequest>()),
                 Times.Once);
         }
@@ -88,9 +88,9 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             SubmitRolloverExtensionApiRequest? captured = null;
 
             _mockApiClient
-                .Setup(c => c.PostWithResponseCodeAsMultipart<SubmitRolloverExtensionCommandResponse>(
-                    It.IsAny<IPostMultipartFormDataApiRequest>()))
-                .Callback<IPostMultipartFormDataApiRequest>(req =>
+                .Setup(c => c.PostWithResponseCodeAsJsonFile<SubmitRolloverExtensionCommandResponse>(
+                    It.IsAny<IPostMultipartJsonFileApiRequest>()))
+                .Callback<IPostMultipartJsonFileApiRequest>(req =>
                 {
                     captured = req as SubmitRolloverExtensionApiRequest;
                 })
@@ -104,44 +104,5 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             Assert.Equal(request, captured!.Data);
         }
 
-        [Fact]
-        public void ApiRequest_WhenItemIsProvided_MapsNestedValuesToMultipartFormData()
-        {
-            // Arrange
-            var proposedEndDate = new DateTime(2026, 7, 31, 10, 15, 0, DateTimeKind.Utc);
-            var request = new SubmitRolloverExtensionApiRequest
-            {
-                Data = new SubmitRolloverExtensionCommand
-                {
-                    Items =
-                    [
-                        new FundingExtensionItem
-                        {
-                            Qan = "123/4567/8",
-                            FundingStreamName = "Adult Skills",
-                            RolloverStatus = "Approved",
-                            ExclusionReason = "Not eligible",
-                            ProposedFundingApprovalEndDate = proposedEndDate,
-                            Comments = "Checked"
-                        }
-                    ]
-                }
-            };
-            KeyValuePair<string, string>[] expected =
-            [
-                new("Items[0].Qan", "123/4567/8"),
-                new("Items[0].FundingStreamName", "Adult Skills"),
-                new("Items[0].RolloverStatus", "Approved"),
-                new("Items[0].ExclusionReason", "Not eligible"),
-                new("Items[0].ProposedFundingApprovalEndDate", "2026-07-31T10:15:00Z"),
-                new("Items[0].Comments", "Checked")
-            ];
-
-            // Act
-            var result = request.FormData.ToArray();
-
-            // Assert
-            result.ShouldBe(expected);
-        }
     }
 }

--- a/src/SFA.DAS.AODP.Application.Tests/Commands/Rollover/SubmitRolloverExtensionCommandHandlerTests.cs
+++ b/src/SFA.DAS.AODP.Application.Tests/Commands/Rollover/SubmitRolloverExtensionCommandHandlerTests.cs
@@ -5,7 +5,7 @@ using SFA.DAS.AODP.Domain.Rollover;
 
 namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
 {
-    public class SubmitRolloverExtensionCommandHandlerTests
+    public class SubmitRolloverExtensionCommandHandlerTests : UnitTest
     {
         private readonly Mock<IApiClient> _mockApiClient;
         private readonly SubmitRolloverExtensionCommandHandler _handler;
@@ -33,12 +33,12 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             };
 
             _mockApiClient
-                .Setup(c => c.PostWithResponseCode<SubmitRolloverExtensionCommandResponse>(
+                .Setup(c => c.PostWithResponseCodeAsMultipart<SubmitRolloverExtensionCommandResponse>(
                     It.IsAny<SubmitRolloverExtensionApiRequest>()))
                 .ReturnsAsync(expectedApiResponse);
 
             // Act
-            var result = await _handler.Handle(request, CancellationToken.None);
+            var result = await _handler.Handle(request, CancellationToken);
 
             // Assert
             Assert.True(result.Success);
@@ -47,7 +47,7 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             Assert.Null(result.ErrorMessage);
 
             _mockApiClient.Verify(c =>
-                c.PostWithResponseCode<SubmitRolloverExtensionCommandResponse>(
+                c.PostWithResponseCodeAsMultipart<SubmitRolloverExtensionCommandResponse>(
                     It.IsAny<SubmitRolloverExtensionApiRequest>()),
                 Times.Once);
         }
@@ -59,19 +59,19 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             var request = new SubmitRolloverExtensionCommand();
 
             _mockApiClient
-                .Setup(c => c.PostWithResponseCode<SubmitRolloverExtensionCommandResponse>(
+                .Setup(c => c.PostWithResponseCodeAsMultipart<SubmitRolloverExtensionCommandResponse>(
                     It.IsAny<SubmitRolloverExtensionApiRequest>()))
                 .ThrowsAsync(new Exception("API failed"));
 
             // Act
-            var result = await _handler.Handle(request, CancellationToken.None);
+            var result = await _handler.Handle(request, CancellationToken);
 
             // Assert
             Assert.False(result.Success);
             Assert.Equal("API failed", result.ErrorMessage);
 
             _mockApiClient.Verify(c =>
-                c.PostWithResponseCode<SubmitRolloverExtensionCommandResponse>(
+                c.PostWithResponseCodeAsMultipart<SubmitRolloverExtensionCommandResponse>(
                     It.IsAny<SubmitRolloverExtensionApiRequest>()),
                 Times.Once);
         }
@@ -88,20 +88,60 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             SubmitRolloverExtensionApiRequest? captured = null;
 
             _mockApiClient
-                .Setup(c => c.PostWithResponseCode<SubmitRolloverExtensionCommandResponse>(
-                    It.IsAny<IPostApiRequest>()))
-                .Callback<IPostApiRequest>(req =>
+                .Setup(c => c.PostWithResponseCodeAsMultipart<SubmitRolloverExtensionCommandResponse>(
+                    It.IsAny<IPostMultipartFormDataApiRequest>()))
+                .Callback<IPostMultipartFormDataApiRequest>(req =>
                 {
                     captured = req as SubmitRolloverExtensionApiRequest;
                 })
                 .ReturnsAsync(new SubmitRolloverExtensionCommandResponse());
 
             // Act
-            await _handler.Handle(request, CancellationToken.None);
+            await _handler.Handle(request, CancellationToken);
 
             // Assert
             Assert.NotNull(captured);
             Assert.Equal(request, captured!.Data);
+        }
+
+        [Fact]
+        public void ApiRequest_WhenItemIsProvided_MapsNestedValuesToMultipartFormData()
+        {
+            // Arrange
+            var proposedEndDate = new DateTime(2026, 7, 31, 10, 15, 0, DateTimeKind.Utc);
+            var request = new SubmitRolloverExtensionApiRequest
+            {
+                Data = new SubmitRolloverExtensionCommand
+                {
+                    Items =
+                    [
+                        new FundingExtensionItem
+                        {
+                            Qan = "123/4567/8",
+                            FundingStreamName = "Adult Skills",
+                            RolloverStatus = "Approved",
+                            ExclusionReason = "Not eligible",
+                            ProposedFundingApprovalEndDate = proposedEndDate,
+                            Comments = "Checked"
+                        }
+                    ]
+                }
+            };
+            KeyValuePair<string, string>[] expected =
+            [
+                new("Items[0].Qan", "123/4567/8"),
+                new("Items[0].FundingStreamName", "Adult Skills"),
+                new("Items[0].RolloverStatus", "Approved"),
+                new("Items[0].ExclusionReason", "Not eligible"),
+                new("Items[0].ProposedFundingApprovalEndDate", "2026-07-31T10:15:00Z"),
+                new("Items[0].Comments", "Checked")
+            ];
+
+            // Act
+            var result = request.FormData.ToArray();
+
+            // Assert
+            result.ShouldBe(expected);
         }
     }
 }

--- a/src/SFA.DAS.AODP.Application.Tests/Commands/Rollover/ValidateRolloverExtensionCommandHandlerTests.cs
+++ b/src/SFA.DAS.AODP.Application.Tests/Commands/Rollover/ValidateRolloverExtensionCommandHandlerTests.cs
@@ -39,7 +39,7 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             };
 
             _mockApiClient
-                .Setup(c => c.PostWithResponseCodeAsMultipart<ValidateRolloverExtensionCommandResponse>(
+                .Setup(c => c.PostWithResponseCodeAsJsonFile<ValidateRolloverExtensionCommandResponse>(
                     It.IsAny<ValidateRolloverExtensionApiRequest>()))
                 .ReturnsAsync(expectedApiResponse);
 
@@ -53,7 +53,7 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             Assert.Null(result.ErrorMessage);
 
             _mockApiClient.Verify(c =>
-                c.PostWithResponseCodeAsMultipart<ValidateRolloverExtensionCommandResponse>(
+                c.PostWithResponseCodeAsJsonFile<ValidateRolloverExtensionCommandResponse>(
                     It.IsAny<ValidateRolloverExtensionApiRequest>()),
                 Times.Once);
         }
@@ -65,7 +65,7 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             var request = new ValidateRolloverExtensionCommand();
 
             _mockApiClient
-                .Setup(c => c.PostWithResponseCodeAsMultipart<ValidateRolloverExtensionCommandResponse>(
+                .Setup(c => c.PostWithResponseCodeAsJsonFile<ValidateRolloverExtensionCommandResponse>(
                     It.IsAny<ValidateRolloverExtensionApiRequest>()))
                 .ThrowsAsync(new Exception("API failed"));
 
@@ -77,7 +77,7 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             Assert.Equal("API failed", result.ErrorMessage);
 
             _mockApiClient.Verify(c =>
-                c.PostWithResponseCodeAsMultipart<ValidateRolloverExtensionCommandResponse>(
+                c.PostWithResponseCodeAsJsonFile<ValidateRolloverExtensionCommandResponse>(
                     It.IsAny<ValidateRolloverExtensionApiRequest>()),
                 Times.Once);
         }
@@ -94,9 +94,9 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             ValidateRolloverExtensionApiRequest? captured = null;
 
             _mockApiClient
-                .Setup(c => c.PostWithResponseCodeAsMultipart<ValidateRolloverExtensionCommandResponse>(
-                    It.IsAny<IPostMultipartFormDataApiRequest>()))
-                .Callback<IPostMultipartFormDataApiRequest>(req =>
+                .Setup(c => c.PostWithResponseCodeAsJsonFile<ValidateRolloverExtensionCommandResponse>(
+                    It.IsAny<IPostMultipartJsonFileApiRequest>()))
+                .Callback<IPostMultipartJsonFileApiRequest>(req =>
                 {
                     captured = req as ValidateRolloverExtensionApiRequest;
                 })
@@ -108,46 +108,6 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             // Assert
             Assert.NotNull(captured);
             Assert.Equal(request, captured!.Data);
-        }
-
-        [Fact]
-        public void ApiRequest_WhenCandidateIsProvided_MapsNestedValuesToMultipartFormData()
-        {
-            // Arrange
-            var proposedEndDate = new DateTime(2026, 7, 31, 10, 15, 0, DateTimeKind.Utc);
-            var request = new ValidateRolloverExtensionApiRequest
-            {
-                Data = new ValidateRolloverExtensionCommand
-                {
-                    RolloverCandidates =
-                    [
-                        new RolloverCandidateForValidation
-                        {
-                            Qan = "123/4567/8",
-                            FundingStreamName = "Adult Skills",
-                            RollOverStatus = "Approved",
-                            ExclusionReason = "Not eligible",
-                            ProposedFundingApprovalEndDate = proposedEndDate,
-                            Comments = "Checked"
-                        }
-                    ]
-                }
-            };
-            KeyValuePair<string, string>[] expected =
-            [
-                new("RolloverCandidates[0].Qan", "123/4567/8"),
-                new("RolloverCandidates[0].FundingStreamName", "Adult Skills"),
-                new("RolloverCandidates[0].RollOverStatus", "Approved"),
-                new("RolloverCandidates[0].ExclusionReason", "Not eligible"),
-                new("RolloverCandidates[0].ProposedFundingApprovalEndDate", "2026-07-31T10:15:00Z"),
-                new("RolloverCandidates[0].Comments", "Checked")
-            ];
-
-            // Act
-            var result = request.FormData.ToArray();
-
-            // Assert
-            result.ShouldBe(expected);
         }
 
     }

--- a/src/SFA.DAS.AODP.Application.Tests/Commands/Rollover/ValidateRolloverExtensionCommandHandlerTests.cs
+++ b/src/SFA.DAS.AODP.Application.Tests/Commands/Rollover/ValidateRolloverExtensionCommandHandlerTests.cs
@@ -5,7 +5,7 @@ using SFA.DAS.AODP.Domain.Rollover;
 
 namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
 {
-    public class ValidateRolloverExtensionCommandHandlerTests
+    public class ValidateRolloverExtensionCommandHandlerTests : UnitTest
     {
         private readonly Mock<IApiClient> _mockApiClient;
         private readonly ValidateRolloverExtensionCommandHandler _handler;
@@ -39,12 +39,12 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             };
 
             _mockApiClient
-                .Setup(c => c.PostWithResponseCode<ValidateRolloverExtensionCommandResponse>(
+                .Setup(c => c.PostWithResponseCodeAsMultipart<ValidateRolloverExtensionCommandResponse>(
                     It.IsAny<ValidateRolloverExtensionApiRequest>()))
                 .ReturnsAsync(expectedApiResponse);
 
             // Act
-            var result = await _handler.Handle(request, CancellationToken.None);
+            var result = await _handler.Handle(request, CancellationToken);
 
             // Assert
             Assert.True(result.Success);
@@ -53,7 +53,7 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             Assert.Null(result.ErrorMessage);
 
             _mockApiClient.Verify(c =>
-                c.PostWithResponseCode<ValidateRolloverExtensionCommandResponse>(
+                c.PostWithResponseCodeAsMultipart<ValidateRolloverExtensionCommandResponse>(
                     It.IsAny<ValidateRolloverExtensionApiRequest>()),
                 Times.Once);
         }
@@ -65,19 +65,19 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             var request = new ValidateRolloverExtensionCommand();
 
             _mockApiClient
-                .Setup(c => c.PostWithResponseCode<ValidateRolloverExtensionCommandResponse>(
+                .Setup(c => c.PostWithResponseCodeAsMultipart<ValidateRolloverExtensionCommandResponse>(
                     It.IsAny<ValidateRolloverExtensionApiRequest>()))
                 .ThrowsAsync(new Exception("API failed"));
 
             // Act
-            var result = await _handler.Handle(request, CancellationToken.None);
+            var result = await _handler.Handle(request, CancellationToken);
 
             // Assert
             Assert.False(result.Success);
             Assert.Equal("API failed", result.ErrorMessage);
 
             _mockApiClient.Verify(c =>
-                c.PostWithResponseCode<ValidateRolloverExtensionCommandResponse>(
+                c.PostWithResponseCodeAsMultipart<ValidateRolloverExtensionCommandResponse>(
                     It.IsAny<ValidateRolloverExtensionApiRequest>()),
                 Times.Once);
         }
@@ -94,20 +94,60 @@ namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
             ValidateRolloverExtensionApiRequest? captured = null;
 
             _mockApiClient
-                .Setup(c => c.PostWithResponseCode<ValidateRolloverExtensionCommandResponse>(
-                    It.IsAny<IPostApiRequest>()))
-                .Callback<IPostApiRequest>(req =>
+                .Setup(c => c.PostWithResponseCodeAsMultipart<ValidateRolloverExtensionCommandResponse>(
+                    It.IsAny<IPostMultipartFormDataApiRequest>()))
+                .Callback<IPostMultipartFormDataApiRequest>(req =>
                 {
                     captured = req as ValidateRolloverExtensionApiRequest;
                 })
                 .ReturnsAsync(new ValidateRolloverExtensionCommandResponse());
 
             // Act
-            await _handler.Handle(request, CancellationToken.None);
+            await _handler.Handle(request, CancellationToken);
 
             // Assert
             Assert.NotNull(captured);
             Assert.Equal(request, captured!.Data);
+        }
+
+        [Fact]
+        public void ApiRequest_WhenCandidateIsProvided_MapsNestedValuesToMultipartFormData()
+        {
+            // Arrange
+            var proposedEndDate = new DateTime(2026, 7, 31, 10, 15, 0, DateTimeKind.Utc);
+            var request = new ValidateRolloverExtensionApiRequest
+            {
+                Data = new ValidateRolloverExtensionCommand
+                {
+                    RolloverCandidates =
+                    [
+                        new RolloverCandidateForValidation
+                        {
+                            Qan = "123/4567/8",
+                            FundingStreamName = "Adult Skills",
+                            RollOverStatus = "Approved",
+                            ExclusionReason = "Not eligible",
+                            ProposedFundingApprovalEndDate = proposedEndDate,
+                            Comments = "Checked"
+                        }
+                    ]
+                }
+            };
+            KeyValuePair<string, string>[] expected =
+            [
+                new("RolloverCandidates[0].Qan", "123/4567/8"),
+                new("RolloverCandidates[0].FundingStreamName", "Adult Skills"),
+                new("RolloverCandidates[0].RollOverStatus", "Approved"),
+                new("RolloverCandidates[0].ExclusionReason", "Not eligible"),
+                new("RolloverCandidates[0].ProposedFundingApprovalEndDate", "2026-07-31T10:15:00Z"),
+                new("RolloverCandidates[0].Comments", "Checked")
+            ];
+
+            // Act
+            var result = request.FormData.ToArray();
+
+            // Assert
+            result.ShouldBe(expected);
         }
 
     }

--- a/src/SFA.DAS.AODP.Application.Tests/Queries/Rollover/WhenHandlingGetQualificationVersionsForRolloverQueryBuilderQuery.cs
+++ b/src/SFA.DAS.AODP.Application.Tests/Queries/Rollover/WhenHandlingGetQualificationVersionsForRolloverQueryBuilderQuery.cs
@@ -14,7 +14,11 @@ public class WhenHandlingGetQualificationVersionsForRolloverQueryBuilderQuery : 
     public async Task Handle_ShouldPostAllSelectedFilterIdsAndReturnQualificationVersions()
     {
         // Arrange
-        var filters = RolloverQueryBuilderRequestMapper.ForAll(new QueryBuilderFilters());
+        var filters = new RolloverQueryBuilderRequest(
+            LevelIds: [1, 2],
+            TypeIds: [3, 4],
+            SectorSubjectAreaIds: ["01", "02"],
+            AwardingOrganisationIds: ["AO1", "AO2"]);
 
         var expectedResponse = new GetQualificationVersionsForRolloverQueryBuilderQueryResponse
         {
@@ -30,7 +34,7 @@ public class WhenHandlingGetQualificationVersionsForRolloverQueryBuilderQuery : 
         };
 
         _apiClientMock
-            .Setup(a => a.PostWithResponseCode<GetQualificationVersionsForRolloverQueryBuilderQueryResponse>(
+            .Setup(a => a.PostWithResponseCodeAsMultipart<GetQualificationVersionsForRolloverQueryBuilderQueryResponse>(
                 It.IsAny<GetQualificationVersionsForRolloverQueryBuilderApiRequest>()))
             .ReturnsAsync(expectedResponse);
 
@@ -42,8 +46,37 @@ public class WhenHandlingGetQualificationVersionsForRolloverQueryBuilderQuery : 
         // Assert
         result.Success.ShouldBeTrue();
         result.Value.QualificationVersions.ShouldBe(expectedResponse.QualificationVersions);
-        _apiClientMock.Verify(a => a.PostWithResponseCode<GetQualificationVersionsForRolloverQueryBuilderQueryResponse>(
+        _apiClientMock.Verify(a => a.PostWithResponseCodeAsMultipart<GetQualificationVersionsForRolloverQueryBuilderQueryResponse>(
             It.Is<GetQualificationVersionsForRolloverQueryBuilderApiRequest>(r => r.Data == filters)), Times.Once);
+    }
+
+    [Fact]
+    public void ApiRequest_WhenFiltersAreProvided_MapsEveryValueToMultipartFormData()
+    {
+        // Arrange
+        var filters = new RolloverQueryBuilderRequest(
+            LevelIds: [1, 2],
+            TypeIds: [3, 4],
+            SectorSubjectAreaIds: ["01", "02"],
+            AwardingOrganisationIds: ["AO1", "AO2"]);
+        var request = new GetQualificationVersionsForRolloverQueryBuilderApiRequest(filters);
+        KeyValuePair<string, string>[] expected =
+        [
+            new("LevelIds", "1"),
+            new("LevelIds", "2"),
+            new("TypeIds", "3"),
+            new("TypeIds", "4"),
+            new("SectorSubjectAreaIds", "01"),
+            new("SectorSubjectAreaIds", "02"),
+            new("AwardingOrganisationIds", "AO1"),
+            new("AwardingOrganisationIds", "AO2")
+        ];
+
+        // Act
+        var result = request.FormData.ToArray();
+
+        // Assert
+        result.ShouldBe(expected);
     }
 
     [Fact]
@@ -55,7 +88,7 @@ public class WhenHandlingGetQualificationVersionsForRolloverQueryBuilderQuery : 
         var exception = new Exception(exceptionMessage);
 
         _apiClientMock
-            .Setup(a => a.PostWithResponseCode<GetQualificationVersionsForRolloverQueryBuilderQueryResponse>(
+            .Setup(a => a.PostWithResponseCodeAsMultipart<GetQualificationVersionsForRolloverQueryBuilderQueryResponse>(
                 It.IsAny<GetQualificationVersionsForRolloverQueryBuilderApiRequest>()))
             .ThrowsAsync(exception);
 

--- a/src/SFA.DAS.AODP.Application.Tests/Queries/Rollover/WhenHandlingGetQualificationVersionsForRolloverQueryBuilderQuery.cs
+++ b/src/SFA.DAS.AODP.Application.Tests/Queries/Rollover/WhenHandlingGetQualificationVersionsForRolloverQueryBuilderQuery.cs
@@ -34,7 +34,7 @@ public class WhenHandlingGetQualificationVersionsForRolloverQueryBuilderQuery : 
         };
 
         _apiClientMock
-            .Setup(a => a.PostWithResponseCodeAsMultipart<GetQualificationVersionsForRolloverQueryBuilderQueryResponse>(
+            .Setup(a => a.PostWithResponseCodeAsJsonFile<GetQualificationVersionsForRolloverQueryBuilderQueryResponse>(
                 It.IsAny<GetQualificationVersionsForRolloverQueryBuilderApiRequest>()))
             .ReturnsAsync(expectedResponse);
 
@@ -46,37 +46,8 @@ public class WhenHandlingGetQualificationVersionsForRolloverQueryBuilderQuery : 
         // Assert
         result.Success.ShouldBeTrue();
         result.Value.QualificationVersions.ShouldBe(expectedResponse.QualificationVersions);
-        _apiClientMock.Verify(a => a.PostWithResponseCodeAsMultipart<GetQualificationVersionsForRolloverQueryBuilderQueryResponse>(
+        _apiClientMock.Verify(a => a.PostWithResponseCodeAsJsonFile<GetQualificationVersionsForRolloverQueryBuilderQueryResponse>(
             It.Is<GetQualificationVersionsForRolloverQueryBuilderApiRequest>(r => r.Data == filters)), Times.Once);
-    }
-
-    [Fact]
-    public void ApiRequest_WhenFiltersAreProvided_MapsEveryValueToMultipartFormData()
-    {
-        // Arrange
-        var filters = new RolloverQueryBuilderRequest(
-            LevelIds: [1, 2],
-            TypeIds: [3, 4],
-            SectorSubjectAreaIds: ["01", "02"],
-            AwardingOrganisationIds: ["AO1", "AO2"]);
-        var request = new GetQualificationVersionsForRolloverQueryBuilderApiRequest(filters);
-        KeyValuePair<string, string>[] expected =
-        [
-            new("LevelIds", "1"),
-            new("LevelIds", "2"),
-            new("TypeIds", "3"),
-            new("TypeIds", "4"),
-            new("SectorSubjectAreaIds", "01"),
-            new("SectorSubjectAreaIds", "02"),
-            new("AwardingOrganisationIds", "AO1"),
-            new("AwardingOrganisationIds", "AO2")
-        ];
-
-        // Act
-        var result = request.FormData.ToArray();
-
-        // Assert
-        result.ShouldBe(expected);
     }
 
     [Fact]
@@ -88,7 +59,7 @@ public class WhenHandlingGetQualificationVersionsForRolloverQueryBuilderQuery : 
         var exception = new Exception(exceptionMessage);
 
         _apiClientMock
-            .Setup(a => a.PostWithResponseCodeAsMultipart<GetQualificationVersionsForRolloverQueryBuilderQueryResponse>(
+            .Setup(a => a.PostWithResponseCodeAsJsonFile<GetQualificationVersionsForRolloverQueryBuilderQueryResponse>(
                 It.IsAny<GetQualificationVersionsForRolloverQueryBuilderApiRequest>()))
             .ThrowsAsync(exception);
 

--- a/src/SFA.DAS.AODP.Application/Commands/Rollover/SubmitRolloverExtensionCommandHandler.cs
+++ b/src/SFA.DAS.AODP.Application/Commands/Rollover/SubmitRolloverExtensionCommandHandler.cs
@@ -21,7 +21,7 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
 
             try
             {
-                var result = await _apiClient.PostWithResponseCodeAsMultipart<SubmitRolloverExtensionCommandResponse>(new SubmitRolloverExtensionApiRequest()
+                var result = await _apiClient.PostWithResponseCodeAsJsonFile<SubmitRolloverExtensionCommandResponse>(new SubmitRolloverExtensionApiRequest()
                 {
                     Data = request
                 });

--- a/src/SFA.DAS.AODP.Application/Commands/Rollover/SubmitRolloverExtensionCommandHandler.cs
+++ b/src/SFA.DAS.AODP.Application/Commands/Rollover/SubmitRolloverExtensionCommandHandler.cs
@@ -21,7 +21,7 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
 
             try
             {
-                var result = await _apiClient.PostWithResponseCode<SubmitRolloverExtensionCommandResponse>(new SubmitRolloverExtensionApiRequest()
+                var result = await _apiClient.PostWithResponseCodeAsMultipart<SubmitRolloverExtensionCommandResponse>(new SubmitRolloverExtensionApiRequest()
                 {
                     Data = request
                 });

--- a/src/SFA.DAS.AODP.Application/Commands/Rollover/ValidateRolloverExtensionCommandHandler.cs
+++ b/src/SFA.DAS.AODP.Application/Commands/Rollover/ValidateRolloverExtensionCommandHandler.cs
@@ -21,7 +21,7 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
 
             try
             {
-                var result = await _apiClient.PostWithResponseCodeAsMultipart<ValidateRolloverExtensionCommandResponse>(new ValidateRolloverExtensionApiRequest()
+                var result = await _apiClient.PostWithResponseCodeAsJsonFile<ValidateRolloverExtensionCommandResponse>(new ValidateRolloverExtensionApiRequest()
                 {
                     Data = request
                 });

--- a/src/SFA.DAS.AODP.Application/Commands/Rollover/ValidateRolloverExtensionCommandHandler.cs
+++ b/src/SFA.DAS.AODP.Application/Commands/Rollover/ValidateRolloverExtensionCommandHandler.cs
@@ -21,7 +21,7 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
 
             try
             {
-                var result = await _apiClient.PostWithResponseCode<ValidateRolloverExtensionCommandResponse>(new ValidateRolloverExtensionApiRequest()
+                var result = await _apiClient.PostWithResponseCodeAsMultipart<ValidateRolloverExtensionCommandResponse>(new ValidateRolloverExtensionApiRequest()
                 {
                     Data = request
                 });

--- a/src/SFA.DAS.AODP.Application/Queries/Review/Rollover/GetQualificationVersionsForRolloverQueryBuilderQueryHandler.cs
+++ b/src/SFA.DAS.AODP.Application/Queries/Review/Rollover/GetQualificationVersionsForRolloverQueryBuilderQueryHandler.cs
@@ -7,7 +7,7 @@ public class GetQualificationVersionsForRolloverQueryBuilderQueryHandler(IApiCli
         GetQualificationVersionsForRolloverQueryBuilderQuery request,
         CancellationToken cancellationToken)
     {
-        var result = await apiClient.PostWithResponseCode<GetQualificationVersionsForRolloverQueryBuilderQueryResponse>(
+        var result = await apiClient.PostWithResponseCodeAsMultipart<GetQualificationVersionsForRolloverQueryBuilderQueryResponse>(
             new GetQualificationVersionsForRolloverQueryBuilderApiRequest(request.Filters));
 
         return new BaseMediatrResponse<GetQualificationVersionsForRolloverQueryBuilderQueryResponse>

--- a/src/SFA.DAS.AODP.Application/Queries/Review/Rollover/GetQualificationVersionsForRolloverQueryBuilderQueryHandler.cs
+++ b/src/SFA.DAS.AODP.Application/Queries/Review/Rollover/GetQualificationVersionsForRolloverQueryBuilderQueryHandler.cs
@@ -7,7 +7,7 @@ public class GetQualificationVersionsForRolloverQueryBuilderQueryHandler(IApiCli
         GetQualificationVersionsForRolloverQueryBuilderQuery request,
         CancellationToken cancellationToken)
     {
-        var result = await apiClient.PostWithResponseCodeAsMultipart<GetQualificationVersionsForRolloverQueryBuilderQueryResponse>(
+        var result = await apiClient.PostWithResponseCodeAsJsonFile<GetQualificationVersionsForRolloverQueryBuilderQueryResponse>(
             new GetQualificationVersionsForRolloverQueryBuilderApiRequest(request.Filters));
 
         return new BaseMediatrResponse<GetQualificationVersionsForRolloverQueryBuilderQueryResponse>

--- a/src/SFA.DAS.AODP.Domain/Interfaces/IApiClient.cs
+++ b/src/SFA.DAS.AODP.Domain/Interfaces/IApiClient.cs
@@ -8,6 +8,7 @@ public interface IApiClient
     Task<TResponse> Put<TResponse>(IPutApiRequest request);
     Task<TResponse?> PostWithResponseCode<TResponse>(IPostApiRequest request);
     Task<TResponse?> PostWithResponseCodeAsMultipart<TResponse>(IPostMultipartFormDataApiRequest request);
+    Task<TResponse?> PostWithResponseCodeAsJsonFile<TResponse>(IPostMultipartJsonFileApiRequest request);
     Task<ApiResponse<TResponse>> PutWithResponseCode<TResponse>(IPutApiRequest request);
     Task PostWithResponseCode(IPostApiRequest request);
     Task Delete(IDeleteApiRequest request);

--- a/src/SFA.DAS.AODP.Domain/Interfaces/IApiClient.cs
+++ b/src/SFA.DAS.AODP.Domain/Interfaces/IApiClient.cs
@@ -7,6 +7,7 @@ public interface IApiClient
     Task<TResponse> Get<TResponse>(IGetApiRequest request);
     Task<TResponse> Put<TResponse>(IPutApiRequest request);
     Task<TResponse?> PostWithResponseCode<TResponse>(IPostApiRequest request);
+    Task<TResponse?> PostWithResponseCodeAsMultipart<TResponse>(IPostMultipartFormDataApiRequest request);
     Task<ApiResponse<TResponse>> PutWithResponseCode<TResponse>(IPutApiRequest request);
     Task PostWithResponseCode(IPostApiRequest request);
     Task Delete(IDeleteApiRequest request);

--- a/src/SFA.DAS.AODP.Domain/Interfaces/IPostMultipartFormDataApiRequest.cs
+++ b/src/SFA.DAS.AODP.Domain/Interfaces/IPostMultipartFormDataApiRequest.cs
@@ -1,0 +1,7 @@
+namespace SFA.DAS.AODP.Domain.Interfaces;
+
+public interface IPostMultipartFormDataApiRequest
+{
+    string PostUrl { get; }
+    IEnumerable<KeyValuePair<string, string>> FormData { get; }
+}

--- a/src/SFA.DAS.AODP.Domain/Interfaces/IPostMultipartJsonFileApiRequest.cs
+++ b/src/SFA.DAS.AODP.Domain/Interfaces/IPostMultipartJsonFileApiRequest.cs
@@ -1,0 +1,7 @@
+namespace SFA.DAS.AODP.Domain.Interfaces;
+
+public interface IPostMultipartJsonFileApiRequest
+{
+    string PostUrl { get; }
+    object Data { get; }
+}

--- a/src/SFA.DAS.AODP.Domain/MultipartFormDataMapper.cs
+++ b/src/SFA.DAS.AODP.Domain/MultipartFormDataMapper.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+
+namespace SFA.DAS.AODP.Domain;
+
+public static class MultipartFormDataMapper
+{
+    public static IEnumerable<KeyValuePair<string, string>> Map(object data)
+    {
+        var element = JsonSerializer.SerializeToElement(data);
+        return Flatten(element, string.Empty);
+    }
+
+    private static IEnumerable<KeyValuePair<string, string>> Flatten(JsonElement element, string key)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var property in element.EnumerateObject())
+                {
+                    var propertyKey = string.IsNullOrEmpty(key) ? property.Name : $"{key}.{property.Name}";
+                    foreach (var value in Flatten(property.Value, propertyKey))
+                    {
+                        yield return value;
+                    }
+                }
+                break;
+
+            case JsonValueKind.Array:
+                var index = 0;
+                foreach (var item in element.EnumerateArray())
+                {
+                    var itemKey = item.ValueKind is JsonValueKind.Object or JsonValueKind.Array
+                        ? $"{key}[{index}]"
+                        : key;
+                    foreach (var value in Flatten(item, itemKey))
+                    {
+                        yield return value;
+                    }
+                    index++;
+                }
+                break;
+
+            case JsonValueKind.String:
+                yield return new KeyValuePair<string, string>(key, element.GetString()!);
+                break;
+
+            case JsonValueKind.Number:
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+                yield return new KeyValuePair<string, string>(key, element.GetRawText());
+                break;
+        }
+    }
+}

--- a/src/SFA.DAS.AODP.Domain/Rollover/GetQualificationVersionsForRolloverQueryBuilderApiRequest.cs
+++ b/src/SFA.DAS.AODP.Domain/Rollover/GetQualificationVersionsForRolloverQueryBuilderApiRequest.cs
@@ -2,11 +2,9 @@
 
 namespace SFA.DAS.AODP.Domain.Rollover;
 
-public class GetQualificationVersionsForRolloverQueryBuilderApiRequest(RolloverQueryBuilderRequest data) : IPostMultipartFormDataApiRequest
+public class GetQualificationVersionsForRolloverQueryBuilderApiRequest(RolloverQueryBuilderRequest data) : IPostMultipartJsonFileApiRequest
 {
     public string PostUrl => "api/rollover/querybuilder/qualificationversions";
 
-    public RolloverQueryBuilderRequest Data { get; } = data;
-
-    public IEnumerable<KeyValuePair<string, string>> FormData => MultipartFormDataMapper.Map(Data);
+    public object Data { get; } = data;
 }

--- a/src/SFA.DAS.AODP.Domain/Rollover/GetQualificationVersionsForRolloverQueryBuilderApiRequest.cs
+++ b/src/SFA.DAS.AODP.Domain/Rollover/GetQualificationVersionsForRolloverQueryBuilderApiRequest.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using SFA.DAS.AODP.Domain.Interfaces;
+﻿using SFA.DAS.AODP.Domain.Interfaces;
 
 namespace SFA.DAS.AODP.Domain.Rollover;
 
@@ -9,11 +8,5 @@ public class GetQualificationVersionsForRolloverQueryBuilderApiRequest(RolloverQ
 
     public RolloverQueryBuilderRequest Data { get; } = data;
 
-    public IEnumerable<KeyValuePair<string, string>> FormData =>
-        Data.LevelIds.Select(id => FormValue(nameof(Data.LevelIds), id.ToString(CultureInfo.InvariantCulture)))
-            .Concat(Data.TypeIds.Select(id => FormValue(nameof(Data.TypeIds), id.ToString(CultureInfo.InvariantCulture))))
-            .Concat(Data.SectorSubjectAreaIds.Select(id => FormValue(nameof(Data.SectorSubjectAreaIds), id)))
-            .Concat(Data.AwardingOrganisationIds.Select(id => FormValue(nameof(Data.AwardingOrganisationIds), id)));
-
-    private static KeyValuePair<string, string> FormValue(string name, string value) => new(name, value);
+    public IEnumerable<KeyValuePair<string, string>> FormData => MultipartFormDataMapper.Map(Data);
 }

--- a/src/SFA.DAS.AODP.Domain/Rollover/GetQualificationVersionsForRolloverQueryBuilderApiRequest.cs
+++ b/src/SFA.DAS.AODP.Domain/Rollover/GetQualificationVersionsForRolloverQueryBuilderApiRequest.cs
@@ -1,10 +1,19 @@
-﻿using SFA.DAS.AODP.Domain.Interfaces;
+﻿using System.Globalization;
+using SFA.DAS.AODP.Domain.Interfaces;
 
 namespace SFA.DAS.AODP.Domain.Rollover;
 
-public class GetQualificationVersionsForRolloverQueryBuilderApiRequest(RolloverQueryBuilderRequest data) : IPostApiRequest
+public class GetQualificationVersionsForRolloverQueryBuilderApiRequest(RolloverQueryBuilderRequest data) : IPostMultipartFormDataApiRequest
 {
-    public object Data { get; set; } = data;
-
     public string PostUrl => "api/rollover/querybuilder/qualificationversions";
+
+    public RolloverQueryBuilderRequest Data { get; } = data;
+
+    public IEnumerable<KeyValuePair<string, string>> FormData =>
+        Data.LevelIds.Select(id => FormValue(nameof(Data.LevelIds), id.ToString(CultureInfo.InvariantCulture)))
+            .Concat(Data.TypeIds.Select(id => FormValue(nameof(Data.TypeIds), id.ToString(CultureInfo.InvariantCulture))))
+            .Concat(Data.SectorSubjectAreaIds.Select(id => FormValue(nameof(Data.SectorSubjectAreaIds), id)))
+            .Concat(Data.AwardingOrganisationIds.Select(id => FormValue(nameof(Data.AwardingOrganisationIds), id)));
+
+    private static KeyValuePair<string, string> FormValue(string name, string value) => new(name, value);
 }

--- a/src/SFA.DAS.AODP.Domain/Rollover/SubmitRolloverExtensionApiRequest.cs
+++ b/src/SFA.DAS.AODP.Domain/Rollover/SubmitRolloverExtensionApiRequest.cs
@@ -4,9 +4,11 @@ using System.Diagnostics.CodeAnalysis;
 namespace SFA.DAS.AODP.Domain.Rollover;
 
 [ExcludeFromCodeCoverage]
-public class SubmitRolloverExtensionApiRequest : IPostApiRequest
+public class SubmitRolloverExtensionApiRequest : IPostMultipartFormDataApiRequest
 {
     public string PostUrl => "api/rollover/submitrolloverextension";
 
     public object Data { get; set; }
+
+    public IEnumerable<KeyValuePair<string, string>> FormData => MultipartFormDataMapper.Map(Data);
 }

--- a/src/SFA.DAS.AODP.Domain/Rollover/SubmitRolloverExtensionApiRequest.cs
+++ b/src/SFA.DAS.AODP.Domain/Rollover/SubmitRolloverExtensionApiRequest.cs
@@ -4,11 +4,9 @@ using System.Diagnostics.CodeAnalysis;
 namespace SFA.DAS.AODP.Domain.Rollover;
 
 [ExcludeFromCodeCoverage]
-public class SubmitRolloverExtensionApiRequest : IPostMultipartFormDataApiRequest
+public class SubmitRolloverExtensionApiRequest : IPostMultipartJsonFileApiRequest
 {
     public string PostUrl => "api/rollover/submitrolloverextension";
 
     public object Data { get; set; }
-
-    public IEnumerable<KeyValuePair<string, string>> FormData => MultipartFormDataMapper.Map(Data);
 }

--- a/src/SFA.DAS.AODP.Domain/Rollover/ValidateRolloverExtensionApiRequest.cs
+++ b/src/SFA.DAS.AODP.Domain/Rollover/ValidateRolloverExtensionApiRequest.cs
@@ -4,9 +4,11 @@ using System.Diagnostics.CodeAnalysis;
 namespace SFA.DAS.AODP.Domain.Rollover;
 
 [ExcludeFromCodeCoverage]
-public class ValidateRolloverExtensionApiRequest : IPostApiRequest
+public class ValidateRolloverExtensionApiRequest : IPostMultipartFormDataApiRequest
 {
     public string PostUrl => "api/rollover/validaterolloverextension";
 
     public object Data { get; set; }
+
+    public IEnumerable<KeyValuePair<string, string>> FormData => MultipartFormDataMapper.Map(Data);
 }

--- a/src/SFA.DAS.AODP.Domain/Rollover/ValidateRolloverExtensionApiRequest.cs
+++ b/src/SFA.DAS.AODP.Domain/Rollover/ValidateRolloverExtensionApiRequest.cs
@@ -4,11 +4,9 @@ using System.Diagnostics.CodeAnalysis;
 namespace SFA.DAS.AODP.Domain.Rollover;
 
 [ExcludeFromCodeCoverage]
-public class ValidateRolloverExtensionApiRequest : IPostMultipartFormDataApiRequest
+public class ValidateRolloverExtensionApiRequest : IPostMultipartJsonFileApiRequest
 {
     public string PostUrl => "api/rollover/validaterolloverextension";
 
     public object Data { get; set; }
-
-    public IEnumerable<KeyValuePair<string, string>> FormData => MultipartFormDataMapper.Map(Data);
 }

--- a/src/SFA.DAS.AODP.Infrastructure.Tests/ApiClient/ApiClientTests.cs
+++ b/src/SFA.DAS.AODP.Infrastructure.Tests/ApiClient/ApiClientTests.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using Microsoft.Extensions.Options;
+using SFA.DAS.AODP.Domain.Rollover;
+using SFA.DAS.AODP.Models.Settings;
+using SFA.DAS.AODP.UnitTests.Helper.Testing;
+using Shouldly;
+using AodpApiClient = SFA.DAS.AODP.Infrastructure.ApiClient.ApiClient;
+
+namespace SFA.DAS.AODP.Infrastructure.UnitTests.ApiClient;
+
+public class ApiClientTests : UnitTest
+{
+    [Fact]
+    public async Task PostWithResponseCodeAsMultipart_WhenRequestIsProvided_SendsMultipartFormData()
+    {
+        // Arrange
+        var handler = new RecordingHttpMessageHandler();
+        var httpClient = new HttpClient(handler);
+        var options = Options.Create(new AodpOuterApiSettings
+        {
+            BaseUrl = "https://aodp.example/",
+            Key = "subscription-key"
+        });
+        var sut = new AodpApiClient(httpClient, options);
+        var request = new GetQualificationVersionsForRolloverQueryBuilderApiRequest(
+            new RolloverQueryBuilderRequest(
+                LevelIds: [1],
+                TypeIds: [2],
+                SectorSubjectAreaIds: ["01"],
+                AwardingOrganisationIds: ["AO1"]));
+        KeyValuePair<string, string>[] expected =
+        [
+            new("LevelIds", "1"),
+            new("TypeIds", "2"),
+            new("SectorSubjectAreaIds", "01"),
+            new("AwardingOrganisationIds", "AO1")
+        ];
+
+        // Act
+        await sut.PostWithResponseCodeAsMultipart<object>(request);
+
+        // Assert
+        handler.ContentType.ShouldStartWith("multipart/form-data");
+        handler.FormData.ShouldBe(expected);
+        handler.RequestUri.ShouldBe(new Uri("https://aodp.example/api/rollover/querybuilder/qualificationversions"));
+    }
+
+    private sealed class RecordingHttpMessageHandler : HttpMessageHandler
+    {
+        public string ContentType { get; private set; } = string.Empty;
+        public KeyValuePair<string, string>[] FormData { get; private set; } = [];
+        public Uri? RequestUri { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            ContentType = request.Content?.Headers.ContentType?.MediaType ?? string.Empty;
+            RequestUri = request.RequestUri;
+
+            var multipartContent = request.Content.ShouldBeOfType<MultipartFormDataContent>();
+            var formData = new List<KeyValuePair<string, string>>();
+            foreach (var content in multipartContent)
+            {
+                var name = content.Headers.ContentDisposition?.Name?.Trim('"') ?? string.Empty;
+                var value = await content.ReadAsStringAsync(cancellationToken);
+                formData.Add(new KeyValuePair<string, string>(name, value));
+            }
+
+            FormData = formData.ToArray();
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}")
+            };
+        }
+    }
+}

--- a/src/SFA.DAS.AODP.Infrastructure.Tests/ApiClient/ApiClientTests.cs
+++ b/src/SFA.DAS.AODP.Infrastructure.Tests/ApiClient/ApiClientTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Microsoft.Extensions.Options;
+using SFA.DAS.AODP.Application.Commands.Rollover;
 using SFA.DAS.AODP.Domain.Rollover;
 using SFA.DAS.AODP.Models.Settings;
 using SFA.DAS.AODP.UnitTests.Helper.Testing;
@@ -45,11 +46,43 @@ public class ApiClientTests : UnitTest
         handler.RequestUri.ShouldBe(new Uri("https://aodp.example/api/rollover/querybuilder/qualificationversions"));
     }
 
+    [Fact]
+    public async Task PostWithResponseCodeAsJsonFile_WhenRequestIsProvided_SendsOneJsonFile()
+    {
+        // Arrange
+        var handler = new RecordingHttpMessageHandler();
+        var sut = new AodpApiClient(new HttpClient(handler), Options.Create(new AodpOuterApiSettings
+        {
+            BaseUrl = "https://aodp.example/",
+            Key = "subscription-key"
+        }));
+        var request = new SubmitRolloverExtensionApiRequest
+        {
+            Data = new SubmitRolloverExtensionCommand
+            {
+                Items = [new FundingExtensionItem { Qan = "12345678" }]
+            }
+        };
+
+        // Act
+        await sut.PostWithResponseCodeAsJsonFile<object>(request);
+
+        // Assert
+        handler.ContentType.ShouldStartWith("multipart/form-data");
+        handler.FormData.Length.ShouldBe(1);
+        handler.FormData.Single().Key.ShouldBe("payload");
+        handler.FormData.Single().Value.ShouldContain("\"Qan\":\"12345678\"");
+        handler.FileNames.ShouldBe(["payload.json"]);
+        handler.PartContentTypes.ShouldBe(["application/json"]);
+    }
+
     private sealed class RecordingHttpMessageHandler : HttpMessageHandler
     {
         public string ContentType { get; private set; } = string.Empty;
         public KeyValuePair<string, string>[] FormData { get; private set; } = [];
         public Uri? RequestUri { get; private set; }
+        public string[] FileNames { get; private set; } = [];
+        public string[] PartContentTypes { get; private set; } = [];
 
         protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
@@ -60,14 +93,20 @@ public class ApiClientTests : UnitTest
 
             var multipartContent = request.Content.ShouldBeOfType<MultipartFormDataContent>();
             var formData = new List<KeyValuePair<string, string>>();
+            var fileNames = new List<string>();
+            var partContentTypes = new List<string>();
             foreach (var content in multipartContent)
             {
                 var name = content.Headers.ContentDisposition?.Name?.Trim('"') ?? string.Empty;
                 var value = await content.ReadAsStringAsync(cancellationToken);
                 formData.Add(new KeyValuePair<string, string>(name, value));
+                fileNames.Add(content.Headers.ContentDisposition?.FileName?.Trim('"') ?? string.Empty);
+                partContentTypes.Add(content.Headers.ContentType?.MediaType ?? string.Empty);
             }
 
             FormData = formData.ToArray();
+            FileNames = fileNames.ToArray();
+            PartContentTypes = partContentTypes.ToArray();
 
             return new HttpResponseMessage(HttpStatusCode.OK)
             {

--- a/src/SFA.DAS.AODP.Infrastructure.Tests/ApiClient/ApiClientTests.cs
+++ b/src/SFA.DAS.AODP.Infrastructure.Tests/ApiClient/ApiClientTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using Microsoft.Extensions.Options;
 using SFA.DAS.AODP.Application.Commands.Rollover;
+using SFA.DAS.AODP.Domain.Interfaces;
 using SFA.DAS.AODP.Domain.Rollover;
 using SFA.DAS.AODP.Models.Settings;
 using SFA.DAS.AODP.UnitTests.Helper.Testing;
@@ -12,27 +13,218 @@ namespace SFA.DAS.AODP.Infrastructure.UnitTests.ApiClient;
 public class ApiClientTests : UnitTest
 {
     [Fact]
+    public async Task Get_WhenResponseIsSuccessful_SendsAuthenticatedRequestAndReturnsBody()
+    {
+        // Arrange
+        var handler = new RecordingHttpMessageHandler();
+        var sut = CreateSut(handler);
+        var request = new TestGetRequest("api/qualifications/123");
+
+        // Act
+        var result = await sut.Get<TestResponse>(request);
+
+        // Assert
+        result.ResultMessage.ShouldBe("Applied");
+        handler.Method.ShouldBe(HttpMethod.Get);
+        handler.RequestUri.ShouldBe(new Uri("https://aodp.example/api/qualifications/123"));
+        handler.Headers["Ocp-Apim-Subscription-Key"].ShouldBe("subscription-key");
+        handler.Headers["X-Version"].ShouldBe("1");
+    }
+
+    [Fact]
+    public async Task Get_WhenResponseIsNotSuccessful_ThrowsHttpRequestException()
+    {
+        // Arrange
+        var handler = new RecordingHttpMessageHandler(HttpStatusCode.BadRequest);
+        var sut = CreateSut(handler);
+
+        // Act
+        var action = () => sut.Get<TestResponse>(new TestGetRequest("api/qualifications/123"));
+
+        // Assert
+        await Should.ThrowAsync<HttpRequestException>(action);
+    }
+
+    [Fact]
+    public async Task Put_WhenResponseIsSuccessful_SendsJsonAndReturnsBody()
+    {
+        // Arrange
+        var handler = new RecordingHttpMessageHandler();
+        var sut = CreateSut(handler);
+        var request = new TestPutRequest("api/qualifications/123", new { Status = "Approved" });
+
+        // Act
+        var result = await sut.Put<TestResponse>(request);
+
+        // Assert
+        result.ResultMessage.ShouldBe("Applied");
+        handler.Method.ShouldBe(HttpMethod.Put);
+        handler.Body.ShouldBe("{\"Status\":\"Approved\"}");
+        handler.ContentType.ShouldBe("application/json; charset=utf-8");
+        handler.VersionPolicy.ShouldBe(HttpVersionPolicy.RequestVersionOrLower);
+    }
+
+    [Fact]
+    public async Task Put_WhenResponseIsNotSuccessful_ThrowsHttpRequestException()
+    {
+        // Arrange
+        var handler = new RecordingHttpMessageHandler(HttpStatusCode.UnprocessableEntity);
+        var sut = CreateSut(handler);
+        var request = new TestPutRequest("api/qualifications/123", new { Status = "Invalid" });
+
+        // Act
+        var action = () => sut.Put<TestResponse>(request);
+
+        // Assert
+        await Should.ThrowAsync<HttpRequestException>(action);
+    }
+
+    [Fact]
+    public async Task Put_WhenNoResponseIsRequired_SendsJsonRequest()
+    {
+        // Arrange
+        var handler = new RecordingHttpMessageHandler();
+        var sut = CreateSut(handler);
+        var request = new TestPutRequest("api/qualifications/123", new { Status = "Approved" });
+
+        // Act
+        await sut.Put(request);
+
+        // Assert
+        handler.Method.ShouldBe(HttpMethod.Put);
+        handler.Body.ShouldBe("{\"Status\":\"Approved\"}");
+        handler.RequestUri.ShouldBe(new Uri("https://aodp.example/api/qualifications/123"));
+    }
+
+    [Fact]
+    public async Task PutWithResponseCode_WhenResponseIsNotSuccessful_ReturnsStatusAndBody()
+    {
+        // Arrange
+        var handler = new RecordingHttpMessageHandler(HttpStatusCode.Conflict);
+        var sut = CreateSut(handler);
+        var request = new TestPutRequest("api/qualifications/123", new { Status = "Approved" });
+
+        // Act
+        var result = await sut.PutWithResponseCode<TestResponse>(request);
+
+        // Assert
+        result.StatusCode.ShouldBe(HttpStatusCode.Conflict);
+        result.Body.ResultMessage.ShouldBe("Applied");
+        result.ErrorContent.ShouldBeNull();
+        handler.Method.ShouldBe(HttpMethod.Put);
+    }
+
+    [Fact]
+    public async Task PostWithResponseCode_WhenResponseIsSuccessful_SendsJsonAndReturnsBody()
+    {
+        // Arrange
+        var handler = new RecordingHttpMessageHandler();
+        var sut = CreateSut(handler);
+        var request = new TestPostRequest("api/qualifications", new { Qan = "12345678" });
+
+        // Act
+        var result = await sut.PostWithResponseCode<TestResponse>(request);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ResultMessage.ShouldBe("Applied");
+        handler.Method.ShouldBe(HttpMethod.Post);
+        handler.Body.ShouldBe("{\"Qan\":\"12345678\"}");
+        handler.ContentType.ShouldBe("application/json; charset=utf-8");
+    }
+
+    [Fact]
+    public async Task PostWithResponseCode_WhenResponseIsNotSuccessful_ThrowsHttpRequestException()
+    {
+        // Arrange
+        var handler = new RecordingHttpMessageHandler(HttpStatusCode.InternalServerError);
+        var sut = CreateSut(handler);
+
+        // Act
+        var action = () => sut.PostWithResponseCode<TestResponse>(
+            new TestPostRequest("api/qualifications", new { Qan = "12345678" }));
+
+        // Assert
+        await Should.ThrowAsync<HttpRequestException>(action);
+    }
+
+    [Fact]
+    public async Task PostWithResponseCode_WhenResponseBodyIsNull_ReturnsNull()
+    {
+        // Arrange
+        var handler = new RecordingHttpMessageHandler(responseContent: "null");
+        var sut = CreateSut(handler);
+        var request = new TestPostRequest("api/qualifications", new { Qan = "12345678" });
+
+        // Act
+        var result = await sut.PostWithResponseCode<TestResponse>(request);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task PostWithResponseCodeAsMultipart_WhenRequestIsProvided_SendsFormFieldsAndReturnsBody()
+    {
+        // Arrange
+        var handler = new RecordingHttpMessageHandler();
+        var sut = CreateSut(handler);
+        var request = new TestMultipartRequest(
+            "api/rollover/validate",
+            [
+                new KeyValuePair<string, string>("Items[0].Qan", "12345678"),
+                new KeyValuePair<string, string>("Items[0].FundingStreamName", "FS1")
+            ]);
+
+        // Act
+        var result = await sut.PostWithResponseCodeAsMultipart<TestResponse>(request);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ResultMessage.ShouldBe("Applied");
+        handler.Method.ShouldBe(HttpMethod.Post);
+        handler.ContentType.ShouldStartWith("multipart/form-data");
+        handler.FormData.ShouldBe(
+        [
+            new KeyValuePair<string, string>("Items[0].Qan", "12345678"),
+            new KeyValuePair<string, string>("Items[0].FundingStreamName", "FS1")
+        ]);
+    }
+
+    [Fact]
+    public async Task PostWithResponseCodeAsMultipart_WhenResponseBodyIsNull_ReturnsNull()
+    {
+        // Arrange
+        var handler = new RecordingHttpMessageHandler(responseContent: "null");
+        var sut = CreateSut(handler);
+        var request = new TestMultipartRequest("api/rollover/validate", []);
+
+        // Act
+        var result = await sut.PostWithResponseCodeAsMultipart<TestResponse>(request);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
     public async Task PostWithResponseCodeAsJsonFile_WhenQueryBuilderRequestIsProvided_SendsOneJsonFile()
     {
         // Arrange
         var handler = new RecordingHttpMessageHandler();
-        var httpClient = new HttpClient(handler);
-        var options = Options.Create(new AodpOuterApiSettings
-        {
-            BaseUrl = "https://aodp.example/",
-            Key = "subscription-key"
-        });
-        var sut = new AodpApiClient(httpClient, options);
+        var sut = CreateSut(handler);
         var request = new GetQualificationVersionsForRolloverQueryBuilderApiRequest(
             new RolloverQueryBuilderRequest(
                 LevelIds: [1],
                 TypeIds: [2],
                 SectorSubjectAreaIds: ["01"],
                 AwardingOrganisationIds: ["AO1"]));
+
         // Act
-        await sut.PostWithResponseCodeAsJsonFile<object>(request);
+        var result = await sut.PostWithResponseCodeAsJsonFile<TestResponse>(request);
 
         // Assert
+        result.ShouldNotBeNull();
+        result.ResultMessage.ShouldBe("Applied");
         handler.ContentType.ShouldStartWith("multipart/form-data");
         handler.FormData.Length.ShouldBe(1);
         handler.FormData.Single().Key.ShouldBe("payload");
@@ -44,15 +236,11 @@ public class ApiClientTests : UnitTest
     }
 
     [Fact]
-    public async Task PostWithResponseCodeAsJsonFile_WhenRequestIsProvided_SendsOneJsonFile()
+    public async Task PostWithResponseCodeAsJsonFile_WhenResponseBodyIsNull_ReturnsNull()
     {
         // Arrange
-        var handler = new RecordingHttpMessageHandler();
-        var sut = new AodpApiClient(new HttpClient(handler), Options.Create(new AodpOuterApiSettings
-        {
-            BaseUrl = "https://aodp.example/",
-            Key = "subscription-key"
-        }));
+        var handler = new RecordingHttpMessageHandler(responseContent: "null");
+        var sut = CreateSut(handler);
         var request = new SubmitRolloverExtensionApiRequest
         {
             Data = new SubmitRolloverExtensionCommand
@@ -62,24 +250,96 @@ public class ApiClientTests : UnitTest
         };
 
         // Act
-        await sut.PostWithResponseCodeAsJsonFile<object>(request);
+        var result = await sut.PostWithResponseCodeAsJsonFile<TestResponse>(request);
 
         // Assert
-        handler.ContentType.ShouldStartWith("multipart/form-data");
+        result.ShouldBeNull();
         handler.FormData.Length.ShouldBe(1);
         handler.FormData.Single().Key.ShouldBe("payload");
         handler.FormData.Single().Value.ShouldContain("\"Qan\":\"12345678\"");
         handler.FileNames.ShouldBe(["payload.json"]);
         handler.PartContentTypes.ShouldBe(["application/json"]);
-        handler.ContentTypeHeader.ShouldNotContain("\"");
     }
 
-    private sealed class RecordingHttpMessageHandler : HttpMessageHandler
+    [Fact]
+    public async Task PostWithResponseCode_WhenNoResponseIsRequired_SendsJsonRequest()
     {
+        // Arrange
+        var handler = new RecordingHttpMessageHandler();
+        var sut = CreateSut(handler);
+        var request = new TestPostRequest("api/qualifications", new { Qan = "12345678" });
+
+        // Act
+        await sut.PostWithResponseCode(request);
+
+        // Assert
+        handler.Method.ShouldBe(HttpMethod.Post);
+        handler.Body.ShouldBe("{\"Qan\":\"12345678\"}");
+        handler.RequestUri.ShouldBe(new Uri("https://aodp.example/api/qualifications"));
+    }
+
+    [Fact]
+    public async Task Delete_WhenRequestIsProvided_SendsAuthenticatedDeleteRequest()
+    {
+        // Arrange
+        var handler = new RecordingHttpMessageHandler();
+        var sut = CreateSut(handler);
+
+        // Act
+        await sut.Delete(new TestDeleteRequest("api/qualifications/123"));
+
+        // Assert
+        handler.Method.ShouldBe(HttpMethod.Delete);
+        handler.RequestUri.ShouldBe(new Uri("https://aodp.example/api/qualifications/123"));
+        handler.Headers["Ocp-Apim-Subscription-Key"].ShouldBe("subscription-key");
+    }
+
+    private static AodpApiClient CreateSut(RecordingHttpMessageHandler handler)
+    {
+        return new AodpApiClient(new HttpClient(handler), Options.Create(new AodpOuterApiSettings
+        {
+            BaseUrl = "https://aodp.example/",
+            Key = "subscription-key"
+        }));
+    }
+
+    private sealed record TestGetRequest(string GetUrl) : IGetApiRequest;
+
+    private sealed record TestDeleteRequest(string DeleteUrl) : IDeleteApiRequest;
+
+    private sealed record TestMultipartRequest(
+        string PostUrl,
+        IEnumerable<KeyValuePair<string, string>> FormData) : IPostMultipartFormDataApiRequest;
+
+    private sealed class TestPutRequest(string putUrl, object data) : IPutApiRequest
+    {
+        public string PutUrl { get; } = putUrl;
+        public object Data { get; set; } = data;
+    }
+
+    private sealed class TestPostRequest(string postUrl, object data) : IPostApiRequest
+    {
+        public string PostUrl { get; } = postUrl;
+        public object Data { get; set; } = data;
+    }
+
+    private sealed class TestResponse
+    {
+        public string ResultMessage { get; set; } = string.Empty;
+    }
+
+    private sealed class RecordingHttpMessageHandler(
+        HttpStatusCode statusCode = HttpStatusCode.OK,
+        string responseContent = "{\"resultMessage\":\"Applied\"}") : HttpMessageHandler
+    {
+        public HttpMethod? Method { get; private set; }
+        public Uri? RequestUri { get; private set; }
         public string ContentType { get; private set; } = string.Empty;
         public string ContentTypeHeader { get; private set; } = string.Empty;
+        public string Body { get; private set; } = string.Empty;
+        public HttpVersionPolicy VersionPolicy { get; private set; }
+        public Dictionary<string, string> Headers { get; } = [];
         public KeyValuePair<string, string>[] FormData { get; private set; } = [];
-        public Uri? RequestUri { get; private set; }
         public string[] FileNames { get; private set; } = [];
         public string[] PartContentTypes { get; private set; } = [];
 
@@ -87,30 +347,42 @@ public class ApiClientTests : UnitTest
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            ContentType = request.Content?.Headers.ContentType?.MediaType ?? string.Empty;
-            ContentTypeHeader = request.Content?.Headers.ContentType?.ToString() ?? string.Empty;
+            Method = request.Method;
             RequestUri = request.RequestUri;
-
-            var multipartContent = request.Content.ShouldBeOfType<MultipartFormDataContent>();
-            var formData = new List<KeyValuePair<string, string>>();
-            var fileNames = new List<string>();
-            var partContentTypes = new List<string>();
-            foreach (var content in multipartContent)
+            VersionPolicy = request.VersionPolicy;
+            ContentType = request.Content?.Headers.ContentType?.ToString() ?? string.Empty;
+            ContentTypeHeader = ContentType;
+            foreach (var header in request.Headers)
             {
-                var name = content.Headers.ContentDisposition?.Name?.Trim('"') ?? string.Empty;
-                var value = await content.ReadAsStringAsync(cancellationToken);
-                formData.Add(new KeyValuePair<string, string>(name, value));
-                fileNames.Add(content.Headers.ContentDisposition?.FileName?.Trim('"') ?? string.Empty);
-                partContentTypes.Add(content.Headers.ContentType?.MediaType ?? string.Empty);
+                Headers[header.Key] = header.Value.Single();
             }
 
-            FormData = formData.ToArray();
-            FileNames = fileNames.ToArray();
-            PartContentTypes = partContentTypes.ToArray();
-
-            return new HttpResponseMessage(HttpStatusCode.OK)
+            if (request.Content is MultipartFormDataContent multipartContent)
             {
-                Content = new StringContent("{}")
+                var formData = new List<KeyValuePair<string, string>>();
+                var fileNames = new List<string>();
+                var partContentTypes = new List<string>();
+                foreach (var content in multipartContent)
+                {
+                    var name = content.Headers.ContentDisposition?.Name?.Trim('"') ?? string.Empty;
+                    var value = await content.ReadAsStringAsync(cancellationToken);
+                    formData.Add(new KeyValuePair<string, string>(name, value));
+                    fileNames.Add(content.Headers.ContentDisposition?.FileName?.Trim('"') ?? string.Empty);
+                    partContentTypes.Add(content.Headers.ContentType?.MediaType ?? string.Empty);
+                }
+
+                FormData = formData.ToArray();
+                FileNames = fileNames.ToArray();
+                PartContentTypes = partContentTypes.ToArray();
+            }
+            else if (request.Content is not null)
+            {
+                Body = await request.Content.ReadAsStringAsync(cancellationToken);
+            }
+
+            return new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(responseContent)
             };
         }
     }

--- a/src/SFA.DAS.AODP.Infrastructure.Tests/ApiClient/ApiClientTests.cs
+++ b/src/SFA.DAS.AODP.Infrastructure.Tests/ApiClient/ApiClientTests.cs
@@ -74,11 +74,13 @@ public class ApiClientTests : UnitTest
         handler.FormData.Single().Value.ShouldContain("\"Qan\":\"12345678\"");
         handler.FileNames.ShouldBe(["payload.json"]);
         handler.PartContentTypes.ShouldBe(["application/json"]);
+        handler.ContentTypeHeader.ShouldNotContain("\"");
     }
 
     private sealed class RecordingHttpMessageHandler : HttpMessageHandler
     {
         public string ContentType { get; private set; } = string.Empty;
+        public string ContentTypeHeader { get; private set; } = string.Empty;
         public KeyValuePair<string, string>[] FormData { get; private set; } = [];
         public Uri? RequestUri { get; private set; }
         public string[] FileNames { get; private set; } = [];
@@ -89,6 +91,7 @@ public class ApiClientTests : UnitTest
             CancellationToken cancellationToken)
         {
             ContentType = request.Content?.Headers.ContentType?.MediaType ?? string.Empty;
+            ContentTypeHeader = request.Content?.Headers.ContentType?.ToString() ?? string.Empty;
             RequestUri = request.RequestUri;
 
             var multipartContent = request.Content.ShouldBeOfType<MultipartFormDataContent>();

--- a/src/SFA.DAS.AODP.Infrastructure.Tests/ApiClient/ApiClientTests.cs
+++ b/src/SFA.DAS.AODP.Infrastructure.Tests/ApiClient/ApiClientTests.cs
@@ -12,7 +12,7 @@ namespace SFA.DAS.AODP.Infrastructure.UnitTests.ApiClient;
 public class ApiClientTests : UnitTest
 {
     [Fact]
-    public async Task PostWithResponseCodeAsMultipart_WhenRequestIsProvided_SendsMultipartFormData()
+    public async Task PostWithResponseCodeAsJsonFile_WhenQueryBuilderRequestIsProvided_SendsOneJsonFile()
     {
         // Arrange
         var handler = new RecordingHttpMessageHandler();
@@ -29,20 +29,17 @@ public class ApiClientTests : UnitTest
                 TypeIds: [2],
                 SectorSubjectAreaIds: ["01"],
                 AwardingOrganisationIds: ["AO1"]));
-        KeyValuePair<string, string>[] expected =
-        [
-            new("LevelIds", "1"),
-            new("TypeIds", "2"),
-            new("SectorSubjectAreaIds", "01"),
-            new("AwardingOrganisationIds", "AO1")
-        ];
-
         // Act
-        await sut.PostWithResponseCodeAsMultipart<object>(request);
+        await sut.PostWithResponseCodeAsJsonFile<object>(request);
 
         // Assert
         handler.ContentType.ShouldStartWith("multipart/form-data");
-        handler.FormData.ShouldBe(expected);
+        handler.FormData.Length.ShouldBe(1);
+        handler.FormData.Single().Key.ShouldBe("payload");
+        handler.FormData.Single().Value.ShouldContain("\"LevelIds\":[1]");
+        handler.FileNames.ShouldBe(["payload.json"]);
+        handler.PartContentTypes.ShouldBe(["application/json"]);
+        handler.ContentTypeHeader.ShouldNotContain("\"");
         handler.RequestUri.ShouldBe(new Uri("https://aodp.example/api/rollover/querybuilder/qualificationversions"));
     }
 

--- a/src/SFA.DAS.AODP.Infrastructure.Tests/Domain/MultipartFormDataMapperTests.cs
+++ b/src/SFA.DAS.AODP.Infrastructure.Tests/Domain/MultipartFormDataMapperTests.cs
@@ -1,0 +1,73 @@
+using SFA.DAS.AODP.UnitTests.Helper.Testing;
+using Shouldly;
+
+namespace SFA.DAS.AODP.Domain.UnitTests;
+
+public class MultipartFormDataMapperTests : UnitTest
+{
+    [Fact]
+    public void Map_WhenDataContainsSupportedShapes_ReturnsFlattenedFormData()
+    {
+        // Arrange
+        var data = new
+        {
+            Name = "qualification",
+            Count = 13_000,
+            Enabled = true,
+            Nested = new { Code = "QAN001" },
+            Values = new object[] { "first", 2, false },
+            Items = new[]
+            {
+                new { Qan = "10000001" },
+                new { Qan = "10000002" }
+            },
+            Groups = new[]
+            {
+                new[] { "A", "B" },
+                new[] { "C" }
+            },
+            EmptyText = string.Empty,
+            Missing = (string?)null
+        };
+        KeyValuePair<string, string>[] expected =
+        [
+            new("Name", "qualification"),
+            new("Count", "13000"),
+            new("Enabled", "true"),
+            new("Nested.Code", "QAN001"),
+            new("Values", "first"),
+            new("Values", "2"),
+            new("Values", "false"),
+            new("Items[0].Qan", "10000001"),
+            new("Items[1].Qan", "10000002"),
+            new("Groups[0]", "A"),
+            new("Groups[0]", "B"),
+            new("Groups[1]", "C"),
+            new("EmptyText", string.Empty)
+        ];
+
+        // Act
+        var result = MultipartFormDataMapper.Map(data).ToArray();
+
+        // Assert
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Map_WhenDataContainsOnlyNullAndEmptyCollections_ReturnsNoFormData()
+    {
+        // Arrange
+        var data = new
+        {
+            Missing = (string?)null,
+            EmptyItems = Array.Empty<object>(),
+            EmptyObject = new { }
+        };
+
+        // Act
+        var result = MultipartFormDataMapper.Map(data);
+
+        // Assert
+        result.ShouldBeEmpty();
+    }
+}

--- a/src/SFA.DAS.AODP.Infrastructure.Tests/SFA.DAS.AODP.Infrastructure.UnitTests.csproj
+++ b/src/SFA.DAS.AODP.Infrastructure.Tests/SFA.DAS.AODP.Infrastructure.UnitTests.csproj
@@ -34,6 +34,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SFA.DAS.AODP.Application\SFA.DAS.AODP.Application.csproj" />
+    <ProjectReference Include="..\SFA.DAS.AODP.UnitTests.Helper\SFA.DAS.AODP.UnitTests.Helper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.AODP.Infrastructure/ApiClient/ApiClient.cs
+++ b/src/SFA.DAS.AODP.Infrastructure/ApiClient/ApiClient.cs
@@ -129,7 +129,7 @@ namespace SFA.DAS.AODP.Infrastructure.ApiClient
 
         public async Task<TResponse?> PostWithResponseCodeAsJsonFile<TResponse>(IPostMultipartJsonFileApiRequest request)
         {
-            using var multipartContent = new MultipartFormDataContent();
+            using var multipartContent = CreateWafCompatibleMultipartContent();
             var jsonContent = new StringContent(JsonConvert.SerializeObject(request.Data), Encoding.UTF8, "application/json");
             multipartContent.Add(jsonContent, "payload", "payload.json");
 
@@ -144,6 +144,21 @@ namespace SFA.DAS.AODP.Infrastructure.ApiClient
 
             response.EnsureSuccessStatusCode();
             return JsonConvert.DeserializeObject<TResponse>(responseContent) ?? default;
+        }
+
+        private static MultipartFormDataContent CreateWafCompatibleMultipartContent()
+        {
+            var boundary = $"---------------------------{Guid.NewGuid():N}";
+            var content = new MultipartFormDataContent(boundary);
+            var boundaryParameter = content.Headers.ContentType?.Parameters
+                .Single(parameter => string.Equals(parameter.Name, "boundary", StringComparison.OrdinalIgnoreCase));
+
+            if (boundaryParameter is not null)
+            {
+                boundaryParameter.Value = boundary;
+            }
+
+            return content;
         }
 
         public async Task PostWithResponseCode(IPostApiRequest request)

--- a/src/SFA.DAS.AODP.Infrastructure/ApiClient/ApiClient.cs
+++ b/src/SFA.DAS.AODP.Infrastructure/ApiClient/ApiClient.cs
@@ -106,6 +106,27 @@ namespace SFA.DAS.AODP.Infrastructure.ApiClient
             return JsonConvert.DeserializeObject<TResponse>(responseContent) ?? default;
         }
 
+        public async Task<TResponse?> PostWithResponseCodeAsMultipart<TResponse>(IPostMultipartFormDataApiRequest request)
+        {
+            using var multipartContent = new MultipartFormDataContent();
+            foreach (var field in request.FormData)
+            {
+                multipartContent.Add(new StringContent(field.Value, Encoding.UTF8), field.Key);
+            }
+
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Post, request.PostUrl)
+            {
+                Content = multipartContent,
+            };
+            AddAuthenticationHeader(requestMessage);
+
+            var response = await _httpClient.SendAsync(requestMessage).ConfigureAwait(false);
+            var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            response.EnsureSuccessStatusCode();
+            return JsonConvert.DeserializeObject<TResponse>(responseContent) ?? default;
+        }
+
         public async Task PostWithResponseCode(IPostApiRequest request)
         {
             var stringContent = new StringContent(JsonConvert.SerializeObject(request.Data), Encoding.UTF8, "application/json");

--- a/src/SFA.DAS.AODP.Infrastructure/ApiClient/ApiClient.cs
+++ b/src/SFA.DAS.AODP.Infrastructure/ApiClient/ApiClient.cs
@@ -127,6 +127,25 @@ namespace SFA.DAS.AODP.Infrastructure.ApiClient
             return JsonConvert.DeserializeObject<TResponse>(responseContent) ?? default;
         }
 
+        public async Task<TResponse?> PostWithResponseCodeAsJsonFile<TResponse>(IPostMultipartJsonFileApiRequest request)
+        {
+            using var multipartContent = new MultipartFormDataContent();
+            var jsonContent = new StringContent(JsonConvert.SerializeObject(request.Data), Encoding.UTF8, "application/json");
+            multipartContent.Add(jsonContent, "payload", "payload.json");
+
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Post, request.PostUrl)
+            {
+                Content = multipartContent,
+            };
+            AddAuthenticationHeader(requestMessage);
+
+            var response = await _httpClient.SendAsync(requestMessage).ConfigureAwait(false);
+            var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            response.EnsureSuccessStatusCode();
+            return JsonConvert.DeserializeObject<TResponse>(responseContent) ?? default;
+        }
+
         public async Task PostWithResponseCode(IPostApiRequest request)
         {
             var stringContent = new StringContent(JsonConvert.SerializeObject(request.Data), Encoding.UTF8, "application/json");


### PR DESCRIPTION
[AWARD-1240]

- Add in workaround code for now to allow for bypassing the request size limit in the WAF by sending the large rollover candidate data as a multipart form data json payload request allowing it to look like a file upload to the WAF 
- Added in new methods in ApiClient to allow for sending a json payload that looks like a file upload and sending to the next layer as a multipart form data
- Temporary workaround whilst a more asynchronous file processing approach is developed

[AWARD-1240]: https://skillsfundingagency.atlassian.net/browse/AWARD-1240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ